### PR TITLE
feat: add channel adapter contracts and review checkpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,15 @@ class BulkQueueRequest(BaseModel):
     draft_ids: list[str]
 
 
+class ReviewCheckpointRequest(BaseModel):
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    notes: str | None = None
+
+
+class ReviewApprovalRequest(BaseModel):
+    reviewer: str = Field(..., min_length=2, max_length=120)
+
+
 @app.get("/health")
 def health():
     return {"ok": True}
@@ -119,6 +128,14 @@ def get_draft(draft_id: str, uid: str = Depends(current_user)):
     return d
 
 
+@app.get("/platforms/{platform}/adapter")
+def adapter_contract(platform: str, uid: str = Depends(current_user)):
+    adapter = store.channel_adapter_contract(platform)
+    if not adapter:
+        raise HTTPException(404, "Platform not found")
+    return {"user_id": uid, "adapter": adapter}
+
+
 @app.patch("/drafts/{draft_id}")
 def update_draft(draft_id: str, content: str, uid: str = Depends(current_user)):
     d = store.update_content(uid, draft_id, content)
@@ -130,6 +147,23 @@ def update_draft(draft_id: str, content: str, uid: str = Depends(current_user)):
 @app.post("/drafts/{draft_id}/queue")
 def queue(draft_id: str, uid: str = Depends(current_user)):
     d = store.queue_now(uid, draft_id)
+    if not d:
+        raise HTTPException(404, "Not found")
+    return d
+
+
+@app.post("/drafts/{draft_id}/review-checkpoint")
+def review_checkpoint(draft_id: str, req: ReviewCheckpointRequest, uid: str = Depends(current_user)):
+    d = store.set_review_checkpoint(uid, draft_id, req.confidence, req.notes)
+    if not d:
+        raise HTTPException(404, "Not found")
+    checkpoint = store.build_review_checkpoint(d, req.confidence)
+    return {"draft": d, "checkpoint": checkpoint}
+
+
+@app.post("/drafts/{draft_id}/approve")
+def approve_review(draft_id: str, req: ReviewApprovalRequest, uid: str = Depends(current_user)):
+    d = store.approve_review(uid, draft_id, req.reviewer)
     if not d:
         raise HTTPException(404, "Not found")
     return d

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -10,6 +10,35 @@ from app.db import session_scope
 from app.models import Draft
 
 
+CHANNEL_ADAPTERS = {
+    "x": {"composer": "content-x.js", "supportsScheduling": True, "requiresApproval": False},
+    "linkedin": {"composer": "content-linkedin.js", "supportsScheduling": True, "requiresApproval": True},
+    "reddit": {"composer": "content-reddit.js", "supportsScheduling": False, "requiresApproval": True},
+    "threads": {"composer": "content-threads.js", "supportsScheduling": False, "requiresApproval": True},
+    "bluesky": {"composer": "content-bluesky.js", "supportsScheduling": True, "requiresApproval": False},
+    "mastodon": {"composer": "content-mastodon.js", "supportsScheduling": True, "requiresApproval": False},
+    "instagram": {"composer": "content-instagram.js", "supportsScheduling": False, "requiresApproval": True},
+}
+
+
+def channel_adapter_contract(platform: str) -> dict | None:
+    adapter = CHANNEL_ADAPTERS.get(platform)
+    if not adapter:
+        return None
+    return {"platform": platform, **adapter}
+
+
+def build_review_checkpoint(draft: dict, confidence: float) -> dict:
+    approval_required = confidence < 0.7 or channel_adapter_contract(draft["platform"])["requiresApproval"]
+    return {
+        "draft_id": draft["id"],
+        "platform": draft["platform"],
+        "confidence": round(confidence, 3),
+        "requires_review": approval_required,
+        "recommended_action": "human_review" if approval_required else "queue",
+    }
+
+
 def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
     out = []
     with session_scope() as s:
@@ -72,6 +101,38 @@ def update_content(user_id: str, draft_id: str, content: str) -> dict | None:
         if not d or d.user_id != user_id:
             return None
         d.content = content
+        return d.to_dict()
+
+
+def set_review_checkpoint(user_id: str, draft_id: str, confidence: float, notes: str | None = None) -> dict | None:
+    with session_scope() as s:
+        d = s.get(Draft, draft_id)
+        if not d or d.user_id != user_id:
+            return None
+        current_plan = d.plan or {}
+        current_plan["review"] = {
+            "confidence": round(confidence, 3),
+            "notes": notes,
+            "requires_review": confidence < 0.7 or channel_adapter_contract(d.platform)["requiresApproval"],
+        }
+        d.plan = current_plan
+        if current_plan["review"]["requires_review"]:
+            d.status = "review_required"
+        return d.to_dict()
+
+
+def approve_review(user_id: str, draft_id: str, reviewer: str) -> dict | None:
+    with session_scope() as s:
+        d = s.get(Draft, draft_id)
+        if not d or d.user_id != user_id:
+            return None
+        current_plan = d.plan or {}
+        review = current_plan.get("review", {})
+        review["approved_by"] = reviewer
+        review["requires_review"] = False
+        current_plan["review"] = review
+        d.plan = current_plan
+        d.status = "queued"
         return d.to_dict()
 
 


### PR DESCRIPTION
## Summary
- add explicit channel adapter contracts for browser-assisted posting
- add review-checkpoint and approval workflow helpers for low-confidence drafts
- expose adapter and review endpoints in the backend API

## Testing
- python3 -m py_compile backend/app/main.py backend/app/store.py backend/app/models.py

Closes #10
Closes #11