### PR TITLE
fix: two runtime bugs in review checkpoint and extension reporting

### DIFF
--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -29,7 +29,8 @@ def channel_adapter_contract(platform: str) -> dict | None:
 
 
 def build_review_checkpoint(draft: dict, confidence: float) -> dict:
-    approval_required = confidence < 0.7 or channel_adapter_contract(draft["platform"])["requiresApproval"]
+    adapter = channel_adapter_contract(draft["platform"])
+    approval_required = confidence < 0.7 or (adapter["requiresApproval"] if adapter else False)
     return {
         "draft_id": draft["id"],
         "platform": draft["platform"],
@@ -110,10 +111,11 @@ def set_review_checkpoint(user_id: str, draft_id: str, confidence: float, notes:
         if not d or d.user_id != user_id:
             return None
         current_plan = d.plan or {}
+        adapter = channel_adapter_contract(d.platform)
         current_plan["review"] = {
             "confidence": round(confidence, 3),
             "notes": notes,
-            "requires_review": confidence < 0.7 or channel_adapter_contract(d.platform)["requiresApproval"],
+            "requires_review": confidence < 0.7 or (adapter["requiresApproval"] if adapter else False),
         }
         d.plan = current_plan
         if current_plan["review"]["requires_review"]:

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -61,7 +61,9 @@ async function report(draftId, { postUrl, error, info }) {
       body: JSON.stringify({
         draft_id: draftId,
         post_url: postUrl ?? null,
-        error: error ?? info ?? null,
+        // info = "needs_user_action" (copy & open) is not an error; only real
+        // failures should mark the draft failed in the backend.
+        error: error ?? null,
       }),
     });
   } catch (e) {


### PR DESCRIPTION
## Summary

- **`store.py`: `TypeError` crash for 8/15 platforms in review checkpoint** — `channel_adapter_contract()` returns `None` for platforms not in `CHANNEL_ADAPTERS` (hackernews, producthunt, medium, devto, email, telegram, discord, slack). Both `build_review_checkpoint` and `set_review_checkpoint` subscripted the return value directly, so any `POST /drafts/{id}/review-checkpoint` call on these platforms raised `TypeError: 'NoneType' object is not subscriptable`. Fixed by caching the adapter result and falling back to `requiresApproval=False` when no adapter is registered (copy-and-open platforms have no automated posting to gate).

- **`background.js`: copy-and-open drafts marked as `failed` instead of `posted`** — The extension's `report()` helper used `error: error ?? info ?? null`, so "needs_user_action: ..." info strings (emitted for every hackernews, producthunt, medium, devto, telegram, discord, slack, and email dispatch) were forwarded to the backend as the `error` field. The backend marks any non-null `error` as `status=failed`, so all successful copy-and-open handoffs appeared as failures in the Activity feed. Fixed by removing the `?? info` fallback so only genuine errors propagate.

## Test plan

- [ ] Call `POST /drafts/{id}/review-checkpoint` with a draft for `hackernews`, `email`, `telegram`, or `devto` — should return 200, not 500
- [ ] Trigger a copy-and-open platform dispatch via the extension — draft should show `posted` in Activity, not `failed`
- [ ] Existing auto-post platforms (linkedin, x, bluesky) — review checkpoint and dispatch behaviour unchanged