### PR TITLE
feat(backend): research loop — pull live signals to ground drafts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Syntax check
         run: python -m compileall -q app
@@ -46,6 +46,11 @@ jobs:
                      assert len(PLATFORMS) == 15; \
                      assert set(PLATFORMS) == set(PLATFORM_RULES.keys()); \
                      print(f'OK — {len(PLATFORMS)} platforms wired')"
+
+      - name: Pytest
+        env:
+          GROQ_API_KEY: dummy-for-tests
+        run: python -m pytest tests/ -q
 
   web:
     name: Web (Next.js)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ web (Next.js 15)  ──►  backend (FastAPI + Postgres)  ──►  Groq (free
 - **Auto-post** on LinkedIn, X, Threads, Bluesky, Mastodon
 - **Assist / copy-and-open** for Reddit, HN, Product Hunt, Medium, Dev.to, Telegram, Discord, Slack
 - **mailto:** for Email — opens your default mail client with subject + body filled
+- **Research loop** pulls live signals from Hacker News, Dev.to, Reddit, and any RSS feed you point it at, so drafts can reference what's actually being discussed today
 - Atomic claim via `SELECT ... FOR UPDATE SKIP LOCKED` so concurrent polls can't double-post
 
 ## Run locally
@@ -63,8 +64,10 @@ Runs in **dev mode** by default (single user, no login). To enable Supabase magi
 ```
 backend/      FastAPI + agentic pipeline + Postgres store
   app/agent.py     plan → write → critique → refine + variations(N)
+  app/research.py  HN / Dev.to / Reddit / RSS signal fetchers (no API keys)
   app/store.py     SQLAlchemy-backed CRUD scoped by user_id
   app/main.py      REST endpoints
+  tests/           pytest, mocked HTTP for research, sqlite-backed for store
 extension/    Chrome MV3 extension that posts via your browser session
   src/background.js     polls /queue, dispatches to content scripts
   src/content-*.js      one per platform
@@ -72,6 +75,27 @@ web/          Next.js 15 + Tailwind + Supabase
   app/page.tsx          composer + draft picker + sticky action bar
   components/           Logo, Marquee, Spotlight, Typewriter, ...
 ```
+
+## Research loop
+
+Generation gets sharper when the agent has fresh signal to ground against.
+Run a research pass before generating, then opt in with `use_research: true`:
+
+```bash
+# pull signals into your account (deduped per user_id)
+curl -X POST http://localhost:8000/research \
+  -H 'content-type: application/json' \
+  -d '{"queries":["ai agents","content automation"],"rss_feeds":["https://news.ycombinator.com/rss"]}'
+
+# generate drafts that reference the top unused snippets
+curl -X POST http://localhost:8000/generate \
+  -H 'content-type: application/json' \
+  -d '{"product":"...","use_research":true}'
+```
+
+Snippets are scored by upstream popularity × recency (48h half-life), deduped
+per `(user_id, url)`, and marked **used** the first time they feed into a
+draft so the next research run pulls fresh material.
 
 ## Deploying the web app
 

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -170,11 +170,22 @@ class SocialAgent:
 
     # --- single polished draft -----------------------------------------------
 
-    def plan(self, product: str) -> Plan:
+    def plan(self, product: str, *, research_context: str | None = None) -> Plan:
         system = (
             "You are a senior content strategist. Produce a tight content plan as strict "
             "JSON: audience (string), angle (string), key_points (3-5 items), tone, cta."
         )
+        if research_context:
+            # Research goes in the *system* prompt as authoritative context, with
+            # an explicit instruction so the model doesn't paraphrase headlines
+            # back as key_points wholesale — we want the angle to be *informed*
+            # by what's trending, not a list of summaries.
+            system += (
+                "\n\nUse the live signals below to ground the angle in current "
+                "conversation. Reference at most one or two by topic where it "
+                "strengthens the pitch; do not list them as key_points.\n\n"
+                f"Live signals:\n{research_context}"
+            )
         data = json.loads(self._chat(system, f"Product:\n{product}", json_mode=True))
         return Plan(
             audience=data["audience"],
@@ -184,7 +195,14 @@ class SocialAgent:
             cta=data["cta"],
         )
 
-    def write(self, platform: str, product: str, plan: Plan) -> str:
+    def write(
+        self,
+        platform: str,
+        product: str,
+        plan: Plan,
+        *,
+        research_context: str | None = None,
+    ) -> str:
         if platform not in PLATFORM_RULES:
             raise ValueError(f"Unknown platform: {platform}")
         system = (
@@ -195,6 +213,12 @@ class SocialAgent:
             f"Product:\n{product}\n\nContent plan:\n{plan.as_prompt_block()}\n\n"
             f"Write the {platform} post."
         )
+        if research_context:
+            user += (
+                "\n\nLive signals you may *optionally* reference where it lifts "
+                "the post. Do not force-fit. Only use what genuinely fits the "
+                f"angle and platform tone:\n{research_context}"
+            )
         return self._chat(system, user).strip()
 
     def critique(self, platform: str, draft: str) -> str:
@@ -214,11 +238,17 @@ class SocialAgent:
         user = f"Original:\n{draft}\n\nFeedback:\n{feedback}\n\nRevise."
         return self._chat(system, user).strip()
 
-    def run(self, product: str, platforms: tuple[str, ...] = PLATFORMS) -> dict:
-        plan_ = self.plan(product)
+    def run(
+        self,
+        product: str,
+        platforms: tuple[str, ...] = PLATFORMS,
+        *,
+        research_context: str | None = None,
+    ) -> dict:
+        plan_ = self.plan(product, research_context=research_context)
         posts = {}
         for platform in platforms:
-            draft = self.write(platform, product, plan_)
+            draft = self.write(platform, product, plan_, research_context=research_context)
             feedback = self.critique(platform, draft)
             final = self.refine(platform, draft, feedback)
             posts[platform] = {"draft": draft, "feedback": feedback, "final": final}
@@ -226,7 +256,14 @@ class SocialAgent:
 
     # --- N variations per platform -------------------------------------------
 
-    def variations(self, product: str, platform: str, n: int = 5) -> list[dict]:
+    def variations(
+        self,
+        product: str,
+        platform: str,
+        n: int = 5,
+        *,
+        research_context: str | None = None,
+    ) -> list[dict]:
         if platform not in PLATFORM_RULES:
             raise ValueError(f"Unknown platform: {platform}")
         if n < 1 or n > 8:
@@ -244,6 +281,12 @@ class SocialAgent:
             f"Use these angles in order:\n{angle_lines}"
         )
         user = f"Product:\n{product}\n\nGenerate {n} variations now."
+        if research_context:
+            user += (
+                "\n\nLive signals you may *optionally* reference where it lifts "
+                "a variation. Don't force-fit; vary which signals (if any) each "
+                f"variation cites:\n{research_context}"
+            )
         raw = self._chat(system, user, json_mode=True, temperature=0.9)
         data = json.loads(raw)
         items = data.get("variations", [])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from app import store  # noqa: E402
 from app.agent import PLATFORMS, SocialAgent  # noqa: E402
 from app.auth import current_user  # noqa: E402
 from app.db import init_db  # noqa: E402
+from app.research import ResearchRequest, format_for_prompt, run_research  # noqa: E402
 
 
 @asynccontextmanager
@@ -43,12 +44,23 @@ app.add_middleware(
 class GenerateRequest(BaseModel):
     product: str = Field(..., min_length=10, max_length=8000)
     platforms: list[str] = Field(default_factory=lambda: list(PLATFORMS))
+    # When true, the agent prepends the user's top unused research snippets
+    # to its plan/write prompts so drafts can reference live conversation.
+    use_research: bool = False
 
 
 class VariationsRequest(BaseModel):
     product: str = Field(..., min_length=10, max_length=8000)
     platform: str
     count: int = Field(default=5, ge=1, le=8)
+    use_research: bool = False
+
+
+class ResearchRunRequest(BaseModel):
+    queries: list[str] = Field(default_factory=list, max_length=10)
+    rss_feeds: list[str] = Field(default_factory=list, max_length=10)
+    sources: list[str] = Field(default_factory=lambda: ["hn", "devto", "reddit", "rss"])
+    per_source_limit: int = Field(default=10, ge=1, le=25)
 
 
 class ScheduleRequest(BaseModel):
@@ -84,25 +96,86 @@ def me(uid: str = Depends(current_user)):
     return {"user_id": uid}
 
 
+def _build_research_context(uid: str, *, enabled: bool) -> tuple[str | None, list[str]]:
+    """Return (prompt block, snippet ids) — empty when disabled or no banked snippets."""
+    if not enabled:
+        return None, []
+    snippets = store.top_snippets_for_agent(uid, limit=8)
+    if not snippets:
+        return None, []
+    # Re-render via ``format_for_prompt`` so we share the truncation/formatting
+    # logic with anything else that wants to feed snippets into a prompt.
+    from app.research import Snippet  # local import to keep the module boundary clean
+
+    objs = [
+        Snippet(
+            source=s["source"],
+            url=s["url"],
+            title=s["title"],
+            snippet=s.get("snippet"),
+            score=s.get("score") or 0.0,
+        )
+        for s in snippets
+    ]
+    return format_for_prompt(objs), [s["id"] for s in snippets]
+
+
 @app.post("/generate")
 def generate(req: GenerateRequest, uid: str = Depends(current_user)):
     invalid = [p for p in req.platforms if p not in PLATFORMS]
     if invalid:
         raise HTTPException(400, f"Invalid platforms: {invalid}. Valid: {PLATFORMS}")
+    research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
-    result = agent.run(req.product, platforms=tuple(req.platforms))
+    result = agent.run(req.product, platforms=tuple(req.platforms), research_context=research_block)
     drafts = store.save_drafts(uid, req.product, result)
-    return {"plan": result["plan"], "drafts": drafts}
+    # Mark every consumed snippet against the *first* draft — keeps the
+    # used/unused signal accurate without needing per-platform attribution.
+    if snippet_ids and drafts:
+        store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
+    return {"plan": result["plan"], "drafts": drafts, "research_used": len(snippet_ids)}
 
 
 @app.post("/variations")
 def variations(req: VariationsRequest, uid: str = Depends(current_user)):
     if req.platform not in PLATFORMS:
         raise HTTPException(400, f"Invalid platform. Valid: {PLATFORMS}")
+    research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
-    items = agent.variations(req.product, req.platform, n=req.count)
+    items = agent.variations(req.product, req.platform, n=req.count, research_context=research_block)
     drafts = store.save_variations(uid, req.product, req.platform, items)
-    return {"drafts": drafts}
+    if snippet_ids and drafts:
+        store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
+    return {"drafts": drafts, "research_used": len(snippet_ids)}
+
+
+# --- research ---------------------------------------------------------------
+
+
+@app.post("/research")
+def research_run(req: ResearchRunRequest, uid: str = Depends(current_user)):
+    if not req.queries and not req.rss_feeds:
+        raise HTTPException(400, "Provide at least one query or RSS feed.")
+    snippets = run_research(
+        ResearchRequest(
+            queries=req.queries,
+            rss_feeds=req.rss_feeds,
+            sources=req.sources,
+            per_source_limit=req.per_source_limit,
+        )
+    )
+    saved = store.upsert_snippets(uid, snippets)
+    return {"fetched": len(snippets), "saved": saved}
+
+
+@app.get("/research")
+def research_list(
+    source: str | None = None,
+    only_unused: bool = False,
+    limit: int = 50,
+    uid: str = Depends(current_user),
+):
+    return store.list_snippets(uid, source=source, only_unused=only_unused, limit=limit)
 
 
 @app.post("/queue-bulk")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, DateTime, Index, String, Text
+from sqlalchemy import JSON, DateTime, Float, Index, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -62,3 +62,65 @@ class Draft(Base):
 
 # Composite index for the "due for posting" query.
 Index("ix_drafts_user_status_sched", Draft.user_id, Draft.status, Draft.scheduled_at)
+
+
+class ResearchSnippet(Base):
+    """A unit of research a user has gathered.
+
+    Sourced from free signal endpoints (HN Algolia, Dev.to, Reddit JSON, RSS).
+    Used by the agent's planning step so drafts reference live conversations
+    instead of just the static product description. Persisted so we can:
+      * dedupe across runs (don't surface the same URL twice)
+      * track which snippets fed into which draft (compounding learning)
+      * power UI lists on the web side without re-fetching upstream
+    """
+
+    __tablename__ = "research_snippets"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+
+    # Where it came from — free-form so new sources don't need a schema bump.
+    source: Mapped[str] = mapped_column(String(32), index=True)  # hn|devto|reddit|rss
+    query: Mapped[str | None] = mapped_column(String(256), nullable=True, index=True)
+
+    url: Mapped[str] = mapped_column(Text)
+    title: Mapped[str] = mapped_column(Text)
+    snippet: Mapped[str | None] = mapped_column(Text, nullable=True)
+    author: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    # 0..1 — combines upstream popularity (points/comments) with recency.
+    score: Mapped[float] = mapped_column(Float, default=0.0, index=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # When this snippet was used by the agent for a draft, store the draft id.
+    # NULL = not yet used (eligible to surface).
+    used_in_draft_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+
+    # Raw payload from the upstream source for forensic / future re-scoring.
+    extra: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    __table_args__ = (
+        # Same URL ingested twice for the same user collapses to one row —
+        # that's the dedup primitive the research loop relies on.
+        UniqueConstraint("user_id", "url", name="uq_research_user_url"),
+        Index("ix_research_user_score", "user_id", "score"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "source": self.source,
+            "query": self.query,
+            "url": self.url,
+            "title": self.title,
+            "snippet": self.snippet,
+            "author": self.author,
+            "score": self.score,
+            "published_at": self.published_at.isoformat() if self.published_at else None,
+            "used_in_draft_id": self.used_in_draft_id,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/backend/app/research.py
+++ b/backend/app/research.py
@@ -1,0 +1,483 @@
+"""Research loop — pull live signals to feed the agent's planning step.
+
+Why this exists
+---------------
+The agent without research only knows what the user typed in the product blurb.
+On X/HN/Reddit, posts that reference the conversation already happening get
+traction; posts that don't get ignored. The research loop pulls *current*
+signals (top HN stories, Dev.to articles, Reddit threads, RSS feeds) so drafts
+can cite what's actually being discussed right now.
+
+Sources are intentionally **free + keyless** to match Fanout's "no third-party
+API keys to authorise" ethos:
+
+- HN Algolia search       https://hn.algolia.com/api  (search by query)
+- Dev.to public articles  https://dev.to/api/articles (filter by tag)
+- Reddit public JSON      https://www.reddit.com/search.json
+- RSS / Atom feeds        any URL the user provides
+
+Each source returns a list of ``Snippet``. The caller (store + agent) is
+responsible for persistence and dedup.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Callable, Iterable
+
+log = logging.getLogger(__name__)
+
+USER_AGENT = "fanout-research/0.1 (+https://github.com/MukundaKatta/fanout)"
+DEFAULT_TIMEOUT = 5.0  # seconds — keep the loop snappy; one slow source mustn't stall a run.
+PER_SOURCE_LIMIT = 10
+RECENCY_HALF_LIFE_HOURS = 48.0  # popularity halves every 2 days
+
+
+# ---------------------------------------------------------------------------
+# Snippet — the unit of research returned by every source.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Snippet:
+    source: str  # "hn" | "devto" | "reddit" | "rss"
+    url: str
+    title: str
+    snippet: str | None = None
+    author: str | None = None
+    score: float = 0.0  # 0..1, computed after fetch (popularity * recency)
+    published_at: datetime | None = None
+    query: str | None = None
+    extra: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["published_at"] = self.published_at.isoformat() if self.published_at else None
+        return d
+
+
+# ---------------------------------------------------------------------------
+# HTTP — stdlib only, so unit tests can monkeypatch ``_http_get`` cleanly
+# without dragging in ``requests`` or ``httpx``. The whole network surface
+# of this module funnels through this one function.
+# ---------------------------------------------------------------------------
+
+
+def _http_get(url: str, timeout: float = DEFAULT_TIMEOUT) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "*/*"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (URLs are validated upstream)
+        return resp.read()
+
+
+def _http_get_json(url: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
+    body = _http_get(url, timeout=timeout)
+    return json.loads(body.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Scoring — blend upstream popularity with recency so the signal mix favours
+# items that are *both* discussed and fresh. Recency uses an exponential
+# half-life so 2-day-old content is worth half what brand-new content is.
+# ---------------------------------------------------------------------------
+
+
+def _recency_factor(published_at: datetime | None, *, now: datetime | None = None) -> float:
+    if published_at is None:
+        return 0.5  # unknown age — neutral
+    now = now or datetime.now(timezone.utc)
+    if published_at.tzinfo is None:
+        published_at = published_at.replace(tzinfo=timezone.utc)
+    hours = max((now - published_at).total_seconds() / 3600.0, 0.0)
+    return 0.5 ** (hours / RECENCY_HALF_LIFE_HOURS)
+
+
+def _normalize(value: float, *, soft_max: float) -> float:
+    """Squash a raw popularity number to [0, 1] using a soft saturation curve.
+
+    ``soft_max`` is the value at which we want the output to be ~0.7 — past
+    that point we compress aggressively so a viral post (10k upvotes) doesn't
+    drown out genuinely-relevant smaller posts.
+    """
+    if value <= 0:
+        return 0.0
+    return 1.0 - math.exp(-value / soft_max)
+
+
+def _compose_score(popularity: float, *, soft_max: float, published_at: datetime | None) -> float:
+    pop = _normalize(popularity, soft_max=soft_max)
+    rec = _recency_factor(published_at)
+    # Geometric mean — both factors must be reasonable to score well.
+    return round((pop * rec) ** 0.5, 4)
+
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+
+def fetch_hn(query: str, *, limit: int = PER_SOURCE_LIMIT) -> list[Snippet]:
+    """Hacker News via Algolia.
+
+    Sorts by relevance to ``query`` and trims to ``limit``. We score against
+    upstream points (soft-max 200 ≈ a respectable HN front-page item).
+    """
+    if not query.strip():
+        return []
+    qs = urllib.parse.urlencode({"query": query, "tags": "story", "hitsPerPage": limit})
+    url = f"https://hn.algolia.com/api/v1/search?{qs}"
+    try:
+        data = _http_get_json(url)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        log.warning("hn fetch failed: %s", e)
+        return []
+
+    out: list[Snippet] = []
+    for hit in data.get("hits", []):
+        title = hit.get("title") or hit.get("story_title")
+        if not title:
+            continue
+        story_url = hit.get("url") or f"https://news.ycombinator.com/item?id={hit.get('objectID')}"
+        published_at = _parse_iso(hit.get("created_at"))
+        points = float(hit.get("points") or 0)
+        comments = float(hit.get("num_comments") or 0)
+        # Comments are a stronger discussion signal than raw points — weight them slightly higher.
+        popularity = points + 1.5 * comments
+        out.append(
+            Snippet(
+                source="hn",
+                url=story_url,
+                title=title,
+                author=hit.get("author"),
+                published_at=published_at,
+                score=_compose_score(popularity, soft_max=200, published_at=published_at),
+                query=query,
+                extra={"points": points, "comments": comments, "object_id": hit.get("objectID")},
+            )
+        )
+    return out
+
+
+def fetch_devto(tag: str, *, limit: int = PER_SOURCE_LIMIT) -> list[Snippet]:
+    """Dev.to public articles for a tag.
+
+    Dev.to's free endpoint takes a single tag (e.g. ``ai``, ``python``).
+    Multi-word queries are sanitised to lowercase + dashes.
+    """
+    norm_tag = "".join(c if c.isalnum() else "-" for c in tag.lower()).strip("-")
+    if not norm_tag:
+        return []
+    qs = urllib.parse.urlencode({"tag": norm_tag, "per_page": limit, "top": 7})
+    url = f"https://dev.to/api/articles?{qs}"
+    try:
+        data = _http_get_json(url)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        log.warning("devto fetch failed: %s", e)
+        return []
+
+    if not isinstance(data, list):
+        return []
+    out: list[Snippet] = []
+    for art in data[:limit]:
+        title = art.get("title")
+        article_url = art.get("url")
+        if not title or not article_url:
+            continue
+        reactions = float(art.get("public_reactions_count") or 0)
+        comments = float(art.get("comments_count") or 0)
+        popularity = reactions + 1.5 * comments
+        published_at = _parse_iso(art.get("published_at"))
+        out.append(
+            Snippet(
+                source="devto",
+                url=article_url,
+                title=title,
+                snippet=art.get("description"),
+                author=(art.get("user") or {}).get("name"),
+                published_at=published_at,
+                score=_compose_score(popularity, soft_max=120, published_at=published_at),
+                query=tag,
+                extra={"reactions": reactions, "comments": comments, "tag": norm_tag},
+            )
+        )
+    return out
+
+
+def fetch_reddit(query: str, *, limit: int = PER_SOURCE_LIMIT) -> list[Snippet]:
+    """Reddit public search JSON.
+
+    Reddit rate-limits unauthed requests; the configured User-Agent helps
+    avoid 429s. We score against upvotes + comments (soft-max 500).
+    """
+    if not query.strip():
+        return []
+    qs = urllib.parse.urlencode({"q": query, "limit": limit, "sort": "hot", "t": "week"})
+    url = f"https://www.reddit.com/search.json?{qs}"
+    try:
+        data = _http_get_json(url)
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        log.warning("reddit fetch failed: %s", e)
+        return []
+
+    out: list[Snippet] = []
+    for child in (data.get("data") or {}).get("children", []):
+        d = child.get("data") or {}
+        title = d.get("title")
+        permalink = d.get("permalink")
+        if not title or not permalink:
+            continue
+        post_url = f"https://www.reddit.com{permalink}"
+        ups = float(d.get("ups") or 0)
+        comments = float(d.get("num_comments") or 0)
+        popularity = ups + 1.5 * comments
+        # Reddit gives unix seconds in created_utc.
+        published_at = _from_unix(d.get("created_utc"))
+        out.append(
+            Snippet(
+                source="reddit",
+                url=post_url,
+                title=title,
+                snippet=d.get("selftext") or None,
+                author=d.get("author"),
+                published_at=published_at,
+                score=_compose_score(popularity, soft_max=500, published_at=published_at),
+                query=query,
+                extra={"ups": ups, "comments": comments, "subreddit": d.get("subreddit")},
+            )
+        )
+    return out
+
+
+def fetch_rss(feed_url: str, *, limit: int = PER_SOURCE_LIMIT) -> list[Snippet]:
+    """RSS / Atom feeds. No popularity signal upstream, so score is recency-only.
+
+    Tolerates both ``<rss><channel><item>`` and ``<feed><entry>`` shapes.
+    """
+    try:
+        body = _http_get(feed_url)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        log.warning("rss fetch failed (%s): %s", feed_url, e)
+        return []
+
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError as e:
+        log.warning("rss parse failed (%s): %s", feed_url, e)
+        return []
+
+    items = _rss_items(root)
+    out: list[Snippet] = []
+    for entry in items[:limit]:
+        title = (entry.get("title") or "").strip()
+        link = entry.get("link") or ""
+        if not title or not link:
+            continue
+        published_at = entry.get("published_at")
+        out.append(
+            Snippet(
+                source="rss",
+                url=link,
+                title=title,
+                snippet=(entry.get("summary") or None),
+                author=entry.get("author"),
+                published_at=published_at,
+                # No popularity → score is purely recency, but capped at 0.7 so
+                # an HN/Reddit hit can still outrank a fresh RSS item.
+                score=round(_recency_factor(published_at) * 0.7, 4),
+                query=feed_url,
+                extra={"feed": feed_url},
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Orchestration — fetch many sources in parallel, sort, dedupe, return.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResearchRequest:
+    queries: list[str] = field(default_factory=list)  # for hn, devto, reddit
+    rss_feeds: list[str] = field(default_factory=list)
+    sources: list[str] = field(default_factory=lambda: ["hn", "devto", "reddit", "rss"])
+    per_source_limit: int = PER_SOURCE_LIMIT
+
+
+SOURCE_FETCHERS: dict[str, Callable[[str, int], list[Snippet]]] = {
+    "hn": lambda q, n: fetch_hn(q, limit=n),
+    "devto": lambda q, n: fetch_devto(q, limit=n),
+    "reddit": lambda q, n: fetch_reddit(q, limit=n),
+    "rss": lambda q, n: fetch_rss(q, limit=n),
+}
+
+
+def run_research(req: ResearchRequest) -> list[Snippet]:
+    """Run every (source, query/feed) pair in parallel, dedupe by URL, sort by score.
+
+    Concurrent fetch is the critical bit — Reddit alone can take 2–3s, and
+    blocking the whole loop on it would push P50 latency above 10s. With the
+    pool, total wall-time is ~max(per-source) + small overhead.
+    """
+    jobs: list[tuple[str, str]] = []
+    for src in req.sources:
+        if src == "rss":
+            jobs.extend(("rss", feed) for feed in req.rss_feeds)
+        elif src in SOURCE_FETCHERS:
+            jobs.extend((src, q) for q in req.queries if q.strip())
+
+    if not jobs:
+        return []
+
+    results: list[Snippet] = []
+    # ``min(8, len(jobs))`` — one worker per job up to a small ceiling so we
+    # don't spin up dozens of threads for a research request with many feeds.
+    with ThreadPoolExecutor(max_workers=min(8, len(jobs))) as pool:
+        futures = {
+            pool.submit(SOURCE_FETCHERS[src], q, req.per_source_limit): (src, q)
+            for src, q in jobs
+        }
+        for fut in as_completed(futures):
+            src, q = futures[fut]
+            try:
+                results.extend(fut.result())
+            except Exception as e:  # noqa: BLE001 — we never want one source to crash the run.
+                log.warning("source %s/%s raised: %s", src, q, e)
+
+    return _dedupe_by_url(sorted(results, key=lambda s: s.score, reverse=True))
+
+
+def format_for_prompt(snippets: Iterable[Snippet], *, max_chars: int = 1800) -> str:
+    """Render snippets as a compact markdown block to drop into an LLM prompt.
+
+    Capped to ``max_chars`` so we don't blow the context window when the user
+    has hundreds of snippets banked.
+    """
+    lines: list[str] = []
+    for s in snippets:
+        # Plenty of detail for the model, no formatting that confuses Llama.
+        line = f"- [{s.source}] {s.title} ({s.url})"
+        if s.snippet:
+            tail = s.snippet.strip().replace("\n", " ")
+            if len(tail) > 180:
+                tail = tail[:177] + "..."
+            line += f"\n    {tail}"
+        lines.append(line)
+        if sum(len(line_) + 1 for line_ in lines) > max_chars:
+            break
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _dedupe_by_url(snippets: list[Snippet]) -> list[Snippet]:
+    seen: set[str] = set()
+    out: list[Snippet] = []
+    for s in snippets:
+        if s.url in seen:
+            continue
+        seen.add(s.url)
+        out.append(s)
+    return out
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    # HN/Dev.to use ``2026-04-26T12:00:00Z`` — Python's ``fromisoformat`` rejects
+    # the trailing Z before 3.11. Replace it for compat.
+    try:
+        normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        try:
+            return parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+
+
+def _from_unix(value: object) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _rss_items(root: ET.Element) -> list[dict]:
+    """Extract a normalised list of dicts from RSS or Atom XML.
+
+    We don't validate the XML — feeds in the wild are messy. We probe for the
+    fields we care about and fall back to ``None`` when something's missing.
+    """
+    items: list[dict] = []
+
+    # RSS 2.0
+    for item in root.iter("item"):
+        items.append(
+            {
+                "title": _text(item.find("title")),
+                "link": _text(item.find("link")),
+                "summary": _text(item.find("description")),
+                "author": _text(item.find("{http://purl.org/dc/elements/1.1/}creator"))
+                or _text(item.find("author")),
+                "published_at": _parse_iso(_text(item.find("pubDate"))),
+            }
+        )
+
+    # Atom — namespaced. Match by local-name suffix to dodge xmlns mismatches.
+    for entry in _iter_local(root, "entry"):
+        link_el = _find_local(entry, "link")
+        link = (link_el.get("href") if link_el is not None else None) or _text(link_el)
+        items.append(
+            {
+                "title": _text(_find_local(entry, "title")),
+                "link": link,
+                "summary": _text(_find_local(entry, "summary"))
+                or _text(_find_local(entry, "content")),
+                "author": _text(_find_local(_find_local(entry, "author"), "name"))
+                if _find_local(entry, "author") is not None
+                else None,
+                "published_at": _parse_iso(_text(_find_local(entry, "published")))
+                or _parse_iso(_text(_find_local(entry, "updated"))),
+            }
+        )
+
+    return items
+
+
+def _text(el: ET.Element | None) -> str | None:
+    if el is None or el.text is None:
+        return None
+    return el.text.strip() or None
+
+
+def _iter_local(root: ET.Element, name: str) -> Iterable[ET.Element]:
+    suffix = f"}}{name}"
+    for el in root.iter():
+        tag = el.tag
+        if tag == name or tag.endswith(suffix):
+            yield el
+
+
+def _find_local(parent: ET.Element | None, name: str) -> ET.Element | None:
+    if parent is None:
+        return None
+    suffix = f"}}{name}"
+    for el in parent:
+        if el.tag == name or el.tag.endswith(suffix):
+            return el
+    return None

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -7,7 +7,8 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import Draft
+from app.models import Draft, ResearchSnippet
+from app.research import Snippet
 
 
 CHANNEL_ADAPTERS = {
@@ -214,3 +215,95 @@ def mark_failed(user_id: str, draft_id: str, error: str) -> dict | None:
         d.status = "failed"
         d.error = error
         return d.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Research snippets
+# ---------------------------------------------------------------------------
+
+
+def upsert_snippets(user_id: str, snippets: list[Snippet]) -> list[dict]:
+    """Persist research snippets, deduping on (user_id, url).
+
+    On conflict we *refresh* the row — score/title/snippet are updated to
+    reflect the latest fetch, but ``used_in_draft_id`` is preserved so we
+    don't lose the link back to a draft that already cited the URL.
+
+    Implemented as ``select-then-insert-or-update`` so the same code path
+    works on Postgres (production) and SQLite in-memory (CI smoke).
+    """
+    out: list[dict] = []
+    with session_scope() as s:
+        for snip in snippets:
+            existing = s.scalar(
+                select(ResearchSnippet)
+                .where(ResearchSnippet.user_id == user_id)
+                .where(ResearchSnippet.url == snip.url)
+            )
+            if existing is None:
+                row = ResearchSnippet(
+                    user_id=user_id,
+                    source=snip.source,
+                    query=snip.query,
+                    url=snip.url,
+                    title=snip.title,
+                    snippet=snip.snippet,
+                    author=snip.author,
+                    score=snip.score,
+                    published_at=snip.published_at,
+                    extra=snip.extra or None,
+                )
+                s.add(row)
+                s.flush()
+                out.append(row.to_dict())
+            else:
+                # Refresh in place — keep ``used_in_draft_id`` and ``id`` stable.
+                existing.score = snip.score
+                existing.title = snip.title
+                existing.snippet = snip.snippet or existing.snippet
+                existing.author = snip.author or existing.author
+                existing.published_at = snip.published_at or existing.published_at
+                existing.extra = snip.extra or existing.extra
+                s.flush()
+                out.append(existing.to_dict())
+    return out
+
+
+def list_snippets(
+    user_id: str,
+    *,
+    source: str | None = None,
+    only_unused: bool = False,
+    limit: int = 50,
+) -> list[dict]:
+    with session_scope() as s:
+        stmt = select(ResearchSnippet).where(ResearchSnippet.user_id == user_id)
+        if source:
+            stmt = stmt.where(ResearchSnippet.source == source)
+        if only_unused:
+            stmt = stmt.where(ResearchSnippet.used_in_draft_id.is_(None))
+        stmt = stmt.order_by(ResearchSnippet.score.desc(), ResearchSnippet.created_at.desc()).limit(limit)
+        return [row.to_dict() for row in s.scalars(stmt)]
+
+
+def top_snippets_for_agent(user_id: str, *, limit: int = 8) -> list[dict]:
+    """Highest-scoring **unused** snippets — what the agent gets fed.
+
+    ``unused`` keeps the loop compounding: every research run pulls in fresh
+    items, the agent consumes them, and they fall out of the next prompt.
+    """
+    return list_snippets(user_id, only_unused=True, limit=limit)
+
+
+def mark_snippets_used(user_id: str, snippet_ids: list[str], draft_id: str) -> int:
+    if not snippet_ids:
+        return 0
+    count = 0
+    with session_scope() as s:
+        for sid in snippet_ids:
+            row = s.get(ResearchSnippet, sid)
+            if row is None or row.user_id != user_id:
+                continue
+            row.used_in_draft_id = draft_id
+            count += 1
+    return count

--- a/backend/migrations/002_research.sql
+++ b/backend/migrations/002_research.sql
@@ -1,0 +1,34 @@
+-- Research snippets: persisted signals that feed the agent's planning step.
+-- See backend/app/research.py for the source list (HN, Dev.to, Reddit, RSS).
+
+CREATE TABLE IF NOT EXISTS research_snippets (
+  id                 TEXT PRIMARY KEY,
+  user_id            TEXT NOT NULL,
+  source             VARCHAR(32) NOT NULL,
+  query              VARCHAR(256),
+  url                TEXT NOT NULL,
+  title              TEXT NOT NULL,
+  snippet            TEXT,
+  author             VARCHAR(128),
+  score              DOUBLE PRECISION NOT NULL DEFAULT 0,
+  published_at       TIMESTAMPTZ,
+  used_in_draft_id   TEXT,
+  extra              JSONB,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- Same URL ingested twice for the same user collapses to one row —
+  -- this is the dedup primitive the research loop relies on.
+  CONSTRAINT uq_research_user_url UNIQUE (user_id, url)
+);
+
+CREATE INDEX IF NOT EXISTS ix_research_user_id     ON research_snippets (user_id);
+CREATE INDEX IF NOT EXISTS ix_research_source      ON research_snippets (source);
+CREATE INDEX IF NOT EXISTS ix_research_query       ON research_snippets (query);
+CREATE INDEX IF NOT EXISTS ix_research_used_draft  ON research_snippets (used_in_draft_id);
+CREATE INDEX IF NOT EXISTS ix_research_user_score  ON research_snippets (user_id, score);
+
+-- Optional Supabase RLS if you ever expose Postgres directly to clients:
+-- ALTER TABLE research_snippets ENABLE ROW LEVEL SECURITY;
+-- CREATE POLICY research_owner ON research_snippets
+--   USING (user_id::uuid = auth.uid())
+--   WITH CHECK (user_id::uuid = auth.uid());

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.3.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest fixtures.
+
+We force ``DATABASE_URL`` to in-memory sqlite **with a shared cache** so every
+connection in a test process sees the same schema. Without ``cache=shared``
+SQLAlchemy's pool gives each connection a fresh in-memory DB and the tables
+are invisible to readers.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Set BEFORE importing app modules — db.py reads DATABASE_URL at import time.
+os.environ["DATABASE_URL"] = (
+    "sqlite+pysqlite:///file:fanout_test?mode=memory&cache=shared&uri=true"
+)
+os.environ.setdefault("GROQ_API_KEY", "dummy-for-tests")
+
+import pytest  # noqa: E402
+
+from app import db  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db():
+    """Drop + recreate the schema between tests so rows don't leak."""
+    db.Base.metadata.drop_all(bind=db.engine)
+    db.Base.metadata.create_all(bind=db.engine)
+    yield
+    db.Base.metadata.drop_all(bind=db.engine)

--- a/backend/tests/test_research.py
+++ b/backend/tests/test_research.py
@@ -1,0 +1,272 @@
+"""Tests for the research module.
+
+Network is mocked at the ``_http_get`` / ``_http_get_json`` boundary — every
+real HTTP call funnels through those two functions, so monkeypatching them is
+sufficient and we never touch the network in tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import research
+from app.research import (
+    ResearchRequest,
+    Snippet,
+    fetch_devto,
+    fetch_hn,
+    fetch_reddit,
+    fetch_rss,
+    format_for_prompt,
+    run_research,
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-source unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_hn_parses_hits(monkeypatch):
+    payload = {
+        "hits": [
+            {
+                "title": "Show HN: A neat thing",
+                "url": "https://example.com/a",
+                "author": "alice",
+                "points": 120,
+                "num_comments": 30,
+                "created_at": "2026-04-26T08:00:00Z",
+                "objectID": "1",
+            },
+            {
+                # no url → falls back to HN item link
+                "story_title": "Ask HN: Question",
+                "objectID": "2",
+                "points": 0,
+                "num_comments": 0,
+                "created_at": "2026-04-25T08:00:00Z",
+            },
+            {"objectID": "3"},  # missing title — must be dropped
+        ]
+    }
+    monkeypatch.setattr(research, "_http_get_json", lambda *a, **kw: payload)
+    out = fetch_hn("agents")
+    assert len(out) == 2
+    assert out[0].title == "Show HN: A neat thing"
+    assert out[0].url == "https://example.com/a"
+    assert out[0].source == "hn"
+    assert 0 < out[0].score <= 1
+    # Fallback URL form for the second hit:
+    assert out[1].url == "https://news.ycombinator.com/item?id=2"
+
+
+def test_fetch_hn_empty_query_skips_network(monkeypatch):
+    called = False
+
+    def boom(*a, **kw):
+        nonlocal called
+        called = True
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(research, "_http_get_json", boom)
+    assert fetch_hn("   ") == []
+    assert not called
+
+
+def test_fetch_hn_swallows_network_errors(monkeypatch):
+    def boom(*a, **kw):
+        raise OSError("network down")
+
+    monkeypatch.setattr(research, "_http_get_json", boom)
+    # Errors must degrade silently — one bad source should never crash a research run.
+    assert fetch_hn("agents") == []
+
+
+def test_fetch_devto_normalises_tag_and_drops_invalid(monkeypatch):
+    seen: dict = {}
+
+    def fake(url, timeout=5.0):
+        seen["url"] = url
+        return [
+            {
+                "title": "Building agents",
+                "url": "https://dev.to/x/agents",
+                "description": "summary",
+                "public_reactions_count": 50,
+                "comments_count": 10,
+                "published_at": "2026-04-25T00:00:00Z",
+                "user": {"name": "Bob"},
+            },
+            {"title": "no url"},  # missing url → dropped
+        ]
+
+    monkeypatch.setattr(research, "_http_get_json", fake)
+    out = fetch_devto("AI Agents")  # space + caps → must become "ai-agents"
+    assert "tag=ai-agents" in seen["url"]
+    assert len(out) == 1
+    assert out[0].author == "Bob"
+
+
+def test_fetch_devto_empty_tag(monkeypatch):
+    monkeypatch.setattr(research, "_http_get_json", lambda *a, **kw: [])
+    assert fetch_devto("!!!") == []  # nothing alphanumeric → no fetch needed
+
+
+def test_fetch_reddit_parses_children(monkeypatch):
+    monkeypatch.setattr(
+        research,
+        "_http_get_json",
+        lambda *a, **kw: {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "title": "AI agents are hot",
+                            "permalink": "/r/foo/comments/abc/",
+                            "selftext": "discussion",
+                            "ups": 200,
+                            "num_comments": 80,
+                            "created_utc": (datetime.now(timezone.utc) - timedelta(hours=4)).timestamp(),
+                            "author": "u1",
+                            "subreddit": "foo",
+                        }
+                    },
+                    {"data": {"title": "no permalink"}},  # dropped
+                ]
+            }
+        },
+    )
+    out = fetch_reddit("agents")
+    assert len(out) == 1
+    assert out[0].url.startswith("https://www.reddit.com/r/foo/comments/")
+    assert out[0].extra["subreddit"] == "foo"
+    assert out[0].score > 0
+
+
+def test_fetch_rss_atom_and_rss20(monkeypatch):
+    rss20 = b"""<?xml version="1.0"?>
+<rss><channel>
+  <item><title>Item A</title><link>https://a.example</link>
+    <description>desc</description><pubDate>Sun, 26 Apr 2026 12:00:00 +0000</pubDate>
+  </item>
+  <item><title>No link</title></item>
+</channel></rss>"""
+
+    monkeypatch.setattr(research, "_http_get", lambda *a, **kw: rss20)
+    out = fetch_rss("https://blog.example/feed.xml")
+    assert [s.title for s in out] == ["Item A"]
+    assert out[0].score > 0  # recency-only score, but non-zero
+
+    atom = b"""<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Atom A</title>
+    <link href="https://a.atom"/>
+    <summary>summary</summary>
+    <updated>2026-04-26T12:00:00Z</updated>
+    <author><name>Bob</name></author>
+  </entry>
+</feed>"""
+    monkeypatch.setattr(research, "_http_get", lambda *a, **kw: atom)
+    out = fetch_rss("https://blog.example/atom.xml")
+    assert [s.title for s in out] == ["Atom A"]
+    assert out[0].author == "Bob"
+    assert out[0].url == "https://a.atom"
+
+
+def test_fetch_rss_bad_xml_returns_empty(monkeypatch):
+    monkeypatch.setattr(research, "_http_get", lambda *a, **kw: b"<not-valid>")
+    assert fetch_rss("https://blog.example/feed.xml") == []
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def test_recency_factor_decay():
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+    # Brand-new content scores ~1
+    assert research._recency_factor(now, now=now) == pytest.approx(1.0, abs=1e-3)
+    # 48h-old content (= half-life) scores ~0.5
+    assert research._recency_factor(now - timedelta(hours=48), now=now) == pytest.approx(0.5, abs=1e-3)
+    # Unknown timestamp → neutral 0.5 (not zero — we don't punish opaque sources)
+    assert research._recency_factor(None) == 0.5
+
+
+def test_compose_score_bounds():
+    now = datetime.now(timezone.utc)
+    s_zero = research._compose_score(0, soft_max=100, published_at=now)
+    s_big = research._compose_score(10_000, soft_max=100, published_at=now)
+    assert s_zero == 0.0
+    assert 0.9 <= s_big <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# run_research — orchestration + dedup
+# ---------------------------------------------------------------------------
+
+
+def test_run_research_dedupes_by_url(monkeypatch):
+    # Both HN and Reddit return the same URL → only one entry in the output.
+    shared = "https://example.com/x"
+
+    def fake_hn(q, limit):
+        return [Snippet(source="hn", url=shared, title="HN copy", score=0.4)]
+
+    def fake_reddit(q, limit):
+        return [Snippet(source="reddit", url=shared, title="Reddit copy", score=0.8)]
+
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "hn", fake_hn)
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "reddit", fake_reddit)
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "devto", lambda *a, **kw: [])
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "rss", lambda *a, **kw: [])
+
+    result = run_research(
+        ResearchRequest(queries=["agents"], sources=["hn", "reddit", "devto"])
+    )
+    assert len(result) == 1
+    # Highest-scoring duplicate wins — Reddit (0.8) here.
+    assert result[0].score == 0.8
+    assert result[0].source == "reddit"
+
+
+def test_run_research_one_source_failure_doesnt_crash(monkeypatch):
+    def good(q, limit):
+        return [Snippet(source="hn", url="https://ok.example", title="ok", score=0.5)]
+
+    def bad(q, limit):
+        raise RuntimeError("boom")
+
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "hn", good)
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "reddit", bad)
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "devto", lambda *a, **kw: [])
+    monkeypatch.setitem(research.SOURCE_FETCHERS, "rss", lambda *a, **kw: [])
+
+    result = run_research(
+        ResearchRequest(queries=["agents"], sources=["hn", "reddit", "devto"])
+    )
+    assert len(result) == 1
+    assert result[0].url == "https://ok.example"
+
+
+def test_run_research_no_jobs_returns_empty():
+    assert run_research(ResearchRequest(queries=[], rss_feeds=[])) == []
+
+
+# ---------------------------------------------------------------------------
+# format_for_prompt — caps total length
+# ---------------------------------------------------------------------------
+
+
+def test_format_for_prompt_truncates():
+    snippets = [
+        Snippet(source="hn", url=f"https://e.com/{i}", title=f"t{i}", snippet="x" * 500)
+        for i in range(20)
+    ]
+    out = format_for_prompt(snippets, max_chars=500)
+    assert len(out) <= 700  # max_chars + tail of last line
+    assert out.startswith("- [hn]")

--- a/backend/tests/test_store_research.py
+++ b/backend/tests/test_store_research.py
@@ -1,0 +1,86 @@
+"""Tests for research-snippet store helpers (sqlite in-memory)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app import store
+from app.research import Snippet
+
+
+def _snip(url: str, *, score: float = 0.5, title: str = "t") -> Snippet:
+    return Snippet(
+        source="hn",
+        url=url,
+        title=title,
+        snippet="s",
+        author="a",
+        score=score,
+        published_at=datetime.now(timezone.utc),
+        query="q",
+        extra={"k": "v"},
+    )
+
+
+def test_upsert_inserts_new_rows():
+    saved = store.upsert_snippets("user1", [_snip("https://a"), _snip("https://b")])
+    assert {row["url"] for row in saved} == {"https://a", "https://b"}
+    assert all(row["used_in_draft_id"] is None for row in saved)
+
+
+def test_upsert_dedupes_per_user_per_url():
+    # First ingest
+    first = store.upsert_snippets("user1", [_snip("https://a", score=0.3, title="old")])
+    first_id = first[0]["id"]
+    # Second ingest with same URL → row updated, id preserved
+    second = store.upsert_snippets("user1", [_snip("https://a", score=0.9, title="new")])
+    assert second[0]["id"] == first_id
+    assert second[0]["score"] == 0.9
+    assert second[0]["title"] == "new"
+
+    # Different user, same URL → independent row
+    other = store.upsert_snippets("user2", [_snip("https://a", score=0.5)])
+    assert other[0]["id"] != first_id
+
+
+def test_top_snippets_for_agent_only_unused_and_score_ordered():
+    rows = store.upsert_snippets(
+        "user1",
+        [
+            _snip("https://a", score=0.9),
+            _snip("https://b", score=0.5),
+            _snip("https://c", score=0.1),
+        ],
+    )
+    # Mark the highest-scoring snippet as used.
+    used_id = next(r["id"] for r in rows if r["url"] == "https://a")
+    store.mark_snippets_used("user1", [used_id], draft_id="draft-xyz")
+
+    top = store.top_snippets_for_agent("user1", limit=10)
+    assert [r["url"] for r in top] == ["https://b", "https://c"]
+
+
+def test_mark_snippets_used_only_affects_owners_rows():
+    rows1 = store.upsert_snippets("user1", [_snip("https://a")])
+    rows2 = store.upsert_snippets("user2", [_snip("https://a")])
+    # user1 tries to mark user2's snippet — must be ignored.
+    n = store.mark_snippets_used("user1", [rows2[0]["id"]], draft_id="dx")
+    assert n == 0
+    # And user1's own snippet flips correctly:
+    n = store.mark_snippets_used("user1", [rows1[0]["id"]], draft_id="dx")
+    assert n == 1
+    assert store.list_snippets("user1", only_unused=True) == []
+
+
+def test_list_snippets_filters():
+    store.upsert_snippets(
+        "user1",
+        [
+            Snippet(source="hn", url="https://a", title="t", score=0.3),
+            Snippet(source="reddit", url="https://b", title="t", score=0.5),
+        ],
+    )
+    hn = store.list_snippets("user1", source="hn")
+    assert [r["url"] for r in hn] == ["https://a"]
+    reddit = store.list_snippets("user1", source="reddit")
+    assert [r["url"] for r in reddit] == ["https://b"]


### PR DESCRIPTION
## Why

Today the agent only knows what's in the product blurb. On X / HN / Reddit, posts that reference the conversation already happening get traction; posts that don't get ignored. This adds a research loop so drafts can cite what's actually being discussed right now.

## What ships

**Sources (free + keyless, matches Fanout's "no third-party API keys" ethos):**
- HN Algolia search
- Dev.to public articles
- Reddit public JSON
- RSS / Atom feeds (any URL)

**Backend:**
- `app/research.py` — per-source fetchers, scoring (popularity × recency, 48h half-life), parallel orchestration via `ThreadPoolExecutor`
- `ResearchSnippet` model + `migrations/002_research.sql`
- Store helpers: `upsert_snippets`, `list_snippets`, `top_snippets_for_agent`, `mark_snippets_used`
- `POST /research` to ingest, `GET /research` to browse
- `/generate` and `/variations` gain optional `use_research: true` — when set, top unused snippets are formatted into the agent's plan + write prompts
- Snippets are deduped per `(user_id, url)` and marked **used** the first time they feed into a draft, so the next research run pulls fresh material — that's the compounding piece

**Tests + CI:**
- 19 pytest tests (mocked HTTP for research, sqlite in-memory for store)
- CI now runs pytest on top of the existing import-smoke check

## Loop

```bash
# pull signals into your account
curl -X POST http://localhost:8000/research \
  -H 'content-type: application/json' \
  -d '{"queries":["ai agents","content automation"],"rss_feeds":["https://news.ycombinator.com/rss"]}'

# generate drafts that reference top unused snippets
curl -X POST http://localhost:8000/generate \
  -H 'content-type: application/json' \
  -d '{"product":"...","use_research":true}'
```

## Test plan

- [x] `pytest tests/` — 19/19 passing locally on Python 3.14
- [x] `python -m compileall -q app` clean
- [x] `from app.main import app` boots, `/research` routes registered, agent contract preserved
- [ ] CI green on push (3.11 + 3.12 matrix)
- [ ] Manual: hit `POST /research` against a running backend with a real query, verify rows in DB, then `POST /generate` with `use_research:true` and check the snippet IDs are flipped to `used_in_draft_id`