### PR TITLE
feat: research/suggest — generate research queries from a product blurb

### DIFF
--- a/.github/workflows/research-tick.yml
+++ b/.github/workflows/research-tick.yml
@@ -1,0 +1,118 @@
+# Research-tick cron — hits POST /research/tick/all on the deployed backend so
+# active research subscriptions auto-fetch on their configured cadence, fanning
+# out across every user in one request.
+#
+# Disabled by default. To enable:
+#   1. Deploy the backend with env var RESEARCH_TICK_SECRET set to a strong random
+#      string (the service auth token for the fan-out endpoint).
+#   2. Set repo VARIABLE  RESEARCH_TICK_ENABLED = "true"
+#   3. Set repo SECRET    RESEARCH_TICK_URL     = "https://api.example.com/research/tick/all"
+#   4. Set repo SECRET    RESEARCH_TICK_SECRET  = "<same value as backend env>"
+#
+# The job is intentionally permissive — a transient backend hiccup should not
+# turn the repo's CI badge red. Failures are logged but the step exits 0.
+# Workflow output shows fetched/skipped counts per run via the JSON response.
+
+name: Research tick
+
+on:
+  schedule:
+    # Hourly — the tick endpoint is idempotent (subs that aren't due yet
+    # get skipped server-side), so cheap to run more often than the
+    # tightest subscription interval.
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    # Manual fire from the Actions tab — handy for smoke-testing after
+    # changing subscription configs.
+
+permissions:
+  contents: read
+
+concurrency:
+  # Tick is idempotent but there's no point queuing a backlog if the cron
+  # somehow runs concurrently with itself.
+  group: research-tick
+  cancel-in-progress: false
+
+jobs:
+  tick:
+    if: vars.RESEARCH_TICK_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Probe required secrets
+        id: probe
+        env:
+          URL: ${{ secrets.RESEARCH_TICK_URL }}
+        run: |
+          if [ -z "$URL" ]; then
+            echo "::warning::RESEARCH_TICK_ENABLED is true but RESEARCH_TICK_URL is unset; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Hit /research/tick/all
+        if: steps.probe.outputs.skip != 'true'
+        env:
+          URL: ${{ secrets.RESEARCH_TICK_URL }}
+          TICK_SECRET: ${{ secrets.RESEARCH_TICK_SECRET }}
+        run: |
+          set -u
+          if [ -z "$TICK_SECRET" ]; then
+            echo "::warning::RESEARCH_TICK_SECRET is unset — backend will reject the request with 403."
+          fi
+          # ``-w`` writes a status-code line we can inspect for non-2xx.
+          # ``--max-time`` caps the request so a hung backend doesn't burn
+          # the whole 5-minute timeout. Body goes to ``response.json``.
+          STATUS=$(curl -sS -X POST "$URL" \
+            -H 'content-type: application/json' \
+            -H "X-Tick-Secret: $TICK_SECRET" \
+            --max-time 90 \
+            -o response.json \
+            -w '%{http_code}' || echo "000")
+          echo "HTTP $STATUS"
+          echo "--- response ---"
+          cat response.json || true
+          echo
+          if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 300 ]; then
+            echo "::warning::Research tick returned HTTP $STATUS — check backend health and secret."
+            # Exit 0 anyway; a flaky backend should not turn the repo red.
+          fi
+
+      - name: Summarize
+        if: steps.probe.outputs.skip != 'true' && always()
+        run: |
+          # The response shape is:
+          #   { "ran": [{"id","name","fetched","error"}, ...], "skipped": [...] }
+          if [ -f response.json ]; then
+            python3 - <<'PY'
+          import json, os, pathlib
+          try:
+              data = json.loads(pathlib.Path("response.json").read_text())
+          except Exception as e:
+              print(f"could not parse response: {e}")
+              raise SystemExit(0)
+          ran = data.get("ran", []) if isinstance(data, dict) else []
+          total = sum(r.get("fetched", 0) or 0 for r in ran)
+          errors = [r for r in ran if r.get("error")]
+          summary = f"Ran {len(ran)} subscriptions, fetched {total} snippets"
+          if errors:
+              summary += f", {len(errors)} with errors"
+          print(summary)
+          # Surface in the workflow run summary so it's visible without clicking in.
+          step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if step_summary:
+              with open(step_summary, "a") as f:
+                  f.write(f"### Research tick\n\n{summary}\n")
+                  for r in ran:
+                      mark = "❌" if r.get("error") else "✅"
+                      f.write(
+                          f"- {mark} `{r.get('name','?')}` — "
+                          f"fetched {r.get('fetched',0)}"
+                      )
+                      if r.get("error"):
+                          f.write(f" — error: `{r['error']}`")
+                      f.write("\n")
+          PY
+          fi

--- a/README.md
+++ b/README.md
@@ -97,6 +97,42 @@ Snippets are scored by upstream popularity × recency (48h half-life), deduped
 per `(user_id, url)`, and marked **used** the first time they feed into a
 draft so the next research run pulls fresh material.
 
+### Autonomous loop (recurring subscriptions)
+
+Save a query/feed config once and let it refresh on its own:
+
+```bash
+# create a daily subscription
+curl -X POST http://localhost:8000/research/subscriptions \
+  -H 'content-type: application/json' \
+  -d '{"name":"AI agents","queries":["ai agents","llm tooling"],"interval_hours":24}'
+
+# tick the loop — runs every active subscription that's due
+curl -X POST http://localhost:8000/research/tick
+```
+
+Two tick endpoints depending on use case:
+
+- **`POST /research/tick`** — per-user, JWT auth. The "Run due now" button on
+  the workbench hits this.
+- **`POST /research/tick/all`** — service-auth (`X-Tick-Secret` header), fans
+  out across every user in one request. **Disabled by default** — set
+  `RESEARCH_TICK_SECRET` env var on the backend to enable.
+
+For a real cron, use `/research/tick/all`. Wire it to **any** scheduler —
+Vercel cron, Render scheduled job, or the bundled GitHub Action at
+`.github/workflows/research-tick.yml`.
+
+To enable the GitHub Action:
+
+1. Set backend env var `RESEARCH_TICK_SECRET` to a strong random string
+2. Set repo **Variable** `RESEARCH_TICK_ENABLED = "true"`
+3. Set repo **Secret** `RESEARCH_TICK_URL` = `https://<your-backend>/research/tick/all`
+4. Set repo **Secret** `RESEARCH_TICK_SECRET` to the same value as step 1
+
+The action runs hourly. The tick endpoint is idempotent — subscriptions that
+aren't due yet are skipped server-side, so over-polling is safe.
+
 ## Deploying the web app
 
 **Easy mode — Vercel native git integration (recommended):**

--- a/backend/app/agent.py
+++ b/backend/app/agent.py
@@ -168,6 +168,46 @@ class SocialAgent:
         resp = self.client.chat.completions.create(**kwargs)
         return resp.choices[0].message.content or ""
 
+    # --- research helpers ----------------------------------------------------
+
+    def suggest_research_queries(self, product: str, *, n: int = 5) -> list[str]:
+        """Suggest ``n`` short search queries to feed the research loop.
+
+        Used by the ``/research`` workbench so a user landing on it for the
+        first time isn't staring at an empty input. We deliberately ask for
+        *short* phrases (2-5 words) because HN Algolia / Reddit / Dev.to all
+        return better signal on tight queries than long sentences.
+        """
+        if not 1 <= n <= 10:
+            raise ValueError("n must be between 1 and 10")
+        system = (
+            "You are a research strategist. Given a product description, "
+            f"produce {n} short search queries (2-5 words each) the maker "
+            "should track on Hacker News / Reddit / Dev.to to find live "
+            "conversation worth referencing in their content. Mix audience "
+            "terms, problem terms, and adjacent space terms. Avoid generic "
+            "single-word queries.\n\n"
+            f'Respond as strict JSON: {{"queries": ["query 1", "query 2", ...]}}'
+        )
+        raw = self._chat(system, f"Product:\n{product}", json_mode=True, temperature=0.5)
+        data = json.loads(raw)
+        items = data.get("queries", [])
+        # Be defensive — Llama occasionally returns nested objects or empty
+        # strings. Strip + dedupe + cap to ``n`` so callers get a clean list.
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in items:
+            if not isinstance(item, str):
+                continue
+            q = item.strip()
+            if not q or q.lower() in seen:
+                continue
+            seen.add(q.lower())
+            out.append(q)
+            if len(out) >= n:
+                break
+        return out
+
     # --- single polished draft -----------------------------------------------
 
     def plan(self, product: str, *, research_context: str | None = None) -> Plan:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,11 @@ class ResearchRunRequest(BaseModel):
     per_source_limit: int = Field(default=10, ge=1, le=25)
 
 
+class ResearchSuggestRequest(BaseModel):
+    product: str = Field(..., min_length=10, max_length=8000)
+    count: int = Field(default=5, ge=1, le=10)
+
+
 class ScheduleRequest(BaseModel):
     scheduled_at: datetime
 
@@ -176,6 +181,19 @@ def research_list(
     uid: str = Depends(current_user),
 ):
     return store.list_snippets(uid, source=source, only_unused=only_unused, limit=limit)
+
+
+@app.post("/research/suggest")
+def research_suggest(req: ResearchSuggestRequest, _uid: str = Depends(current_user)):
+    """Suggest research queries from a product blurb.
+
+    Cheap (~1s) read-only call — no DB writes — so it's safe to wire to a
+    button on the workbench that the user might click before banking
+    anything. ``_uid`` is required so anon callers can't burn Groq quota.
+    """
+    agent = SocialAgent()
+    queries = agent.suggest_research_queries(req.product, n=req.count)
+    return {"queries": queries}
 
 
 @app.post("/queue-bulk")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -12,7 +13,7 @@ from dotenv import load_dotenv
 # Load .env from the backend root regardless of cwd.
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
-from fastapi import Depends, FastAPI, HTTPException  # noqa: E402
+from fastapi import Depends, FastAPI, Header, HTTPException  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from pydantic import BaseModel, Field  # noqa: E402
 
@@ -66,6 +67,24 @@ class ResearchRunRequest(BaseModel):
 class ResearchSuggestRequest(BaseModel):
     product: str = Field(..., min_length=10, max_length=8000)
     count: int = Field(default=5, ge=1, le=10)
+
+
+class SubscriptionCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    queries: list[str] = Field(default_factory=list, max_length=10)
+    rss_feeds: list[str] = Field(default_factory=list, max_length=10)
+    sources: list[str] = Field(default_factory=lambda: ["hn", "devto", "reddit", "rss"])
+    interval_hours: int = Field(default=24, ge=1, le=24 * 7)
+    active: bool = True
+
+
+class SubscriptionUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+    queries: list[str] | None = Field(default=None, max_length=10)
+    rss_feeds: list[str] | None = Field(default=None, max_length=10)
+    sources: list[str] | None = None
+    interval_hours: int | None = Field(default=None, ge=1, le=24 * 7)
+    active: bool | None = None
 
 
 class ScheduleRequest(BaseModel):
@@ -133,9 +152,11 @@ def generate(req: GenerateRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     result = agent.run(req.product, platforms=tuple(req.platforms), research_context=research_block)
-    drafts = store.save_drafts(uid, req.product, result)
-    # Mark every consumed snippet against the *first* draft — keeps the
-    # used/unused signal accurate without needing per-platform attribution.
+    drafts = store.save_drafts(uid, req.product, result, cited_snippet_ids=snippet_ids)
+    # Snippets are stamped with the *first* draft for the legacy used_in_draft_id
+    # field (kept for back-compat with the snippet list filter), but the canonical
+    # attribution lives on each draft's ``cited_snippet_ids`` JSON column — so
+    # GET /drafts/<id>/citations works for *every* draft in the run, not just one.
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"plan": result["plan"], "drafts": drafts, "research_used": len(snippet_ids)}
@@ -148,7 +169,9 @@ def variations(req: VariationsRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     items = agent.variations(req.product, req.platform, n=req.count, research_context=research_block)
-    drafts = store.save_variations(uid, req.product, req.platform, items)
+    drafts = store.save_variations(
+        uid, req.product, req.platform, items, cited_snippet_ids=snippet_ids
+    )
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"drafts": drafts, "research_used": len(snippet_ids)}
@@ -196,6 +219,135 @@ def research_suggest(req: ResearchSuggestRequest, _uid: str = Depends(current_us
     return {"queries": queries}
 
 
+# --- research subscriptions -------------------------------------------------
+
+
+def _run_subscription(sub: dict) -> tuple[int, str | None]:
+    """Run a single subscription, return ``(fetched_count, error_message_or_None)``.
+
+    Errors are swallowed at the source level inside ``run_research`` (so a
+    flaky upstream doesn't crash the whole tick), but a top-level exception
+    here is recorded on the subscription so the user can see it in the UI.
+    """
+    try:
+        snippets = run_research(
+            ResearchRequest(
+                queries=list(sub.get("queries") or []),
+                rss_feeds=list(sub.get("rss_feeds") or []),
+                sources=list(sub.get("sources") or ["hn", "devto", "reddit", "rss"]),
+            )
+        )
+        store.upsert_snippets(sub["user_id"], snippets)
+        return len(snippets), None
+    except Exception as e:  # noqa: BLE001 — recorded against the subscription, not raised.
+        return 0, str(e)[:500]
+
+
+@app.post("/research/subscriptions", status_code=201)
+def subscription_create(req: SubscriptionCreateRequest, uid: str = Depends(current_user)):
+    if not req.queries and not req.rss_feeds:
+        raise HTTPException(400, "Provide at least one query or RSS feed.")
+    try:
+        sub = store.create_subscription(
+            uid,
+            name=req.name,
+            queries=req.queries,
+            rss_feeds=req.rss_feeds,
+            sources=req.sources,
+            interval_hours=req.interval_hours,
+            active=req.active,
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return sub
+
+
+@app.get("/research/subscriptions")
+def subscription_list(uid: str = Depends(current_user)):
+    return store.list_subscriptions(uid)
+
+
+@app.patch("/research/subscriptions/{sub_id}")
+def subscription_update(
+    sub_id: str, req: SubscriptionUpdateRequest, uid: str = Depends(current_user)
+):
+    try:
+        sub = store.update_subscription(
+            uid,
+            sub_id,
+            name=req.name,
+            queries=req.queries,
+            rss_feeds=req.rss_feeds,
+            sources=req.sources,
+            interval_hours=req.interval_hours,
+            active=req.active,
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    if sub is None:
+        raise HTTPException(404, "Not found")
+    return sub
+
+
+@app.delete("/research/subscriptions/{sub_id}")
+def subscription_delete(sub_id: str, uid: str = Depends(current_user)):
+    if not store.delete_subscription(uid, sub_id):
+        raise HTTPException(404, "Not found")
+    return {"deleted": sub_id}
+
+
+@app.post("/research/tick")
+def research_tick(uid: str = Depends(current_user)):
+    """Run every due subscription belonging to the authed user, in sequence.
+
+    Per-user, idempotent (skips subs that aren't due). Used by the workbench
+    "Run due now" button. For a platform-wide cron, see ``/research/tick/all``
+    which auths via service secret and fans out across every user.
+    """
+    due = store.due_subscriptions(user_id=uid)
+    ran: list[dict] = []
+    for sub in due:
+        fetched, error = _run_subscription(sub)
+        store.mark_subscription_run(sub["id"], fetched=fetched, error=error)
+        ran.append({"id": sub["id"], "name": sub["name"], "fetched": fetched, "error": error})
+    return {"ran": ran, "skipped": []}
+
+
+@app.post("/research/tick/all")
+def research_tick_all(x_tick_secret: str | None = Header(default=None)):
+    """Service-auth tick — runs every due subscription across **all** users.
+
+    Auths via the ``X-Tick-Secret`` header rather than a user JWT, so a single
+    GitHub Action / Vercel cron / Render scheduled job can drive the loop for
+    everyone with one secret. Falls back to 403 when ``RESEARCH_TICK_SECRET``
+    isn't set on the server, so the endpoint is **off by default**.
+    """
+    expected = os.environ.get("RESEARCH_TICK_SECRET")
+    if not expected:
+        raise HTTPException(
+            403, "Service tick disabled — set RESEARCH_TICK_SECRET on the backend to enable."
+        )
+    # Constant-time compare to dodge timing-side-channel guesses on the secret.
+    if not x_tick_secret or not secrets.compare_digest(x_tick_secret, expected):
+        raise HTTPException(403, "Invalid X-Tick-Secret header")
+
+    due = store.due_subscriptions()  # no user filter → all active subs
+    ran: list[dict] = []
+    for sub in due:
+        fetched, error = _run_subscription(sub)
+        store.mark_subscription_run(sub["id"], fetched=fetched, error=error)
+        ran.append(
+            {
+                "id": sub["id"],
+                "user_id": sub["user_id"],
+                "name": sub["name"],
+                "fetched": fetched,
+                "error": error,
+            }
+        )
+    return {"ran": ran, "skipped": []}
+
+
 @app.post("/queue-bulk")
 def queue_bulk(req: BulkQueueRequest, uid: str = Depends(current_user)):
     queued = []
@@ -217,6 +369,20 @@ def get_draft(draft_id: str, uid: str = Depends(current_user)):
     if not d:
         raise HTTPException(404, "Not found")
     return d
+
+
+@app.get("/drafts/{draft_id}/citations")
+def draft_citations(draft_id: str, uid: str = Depends(current_user)):
+    """Return the research snippets that fed this draft's prompt.
+
+    Empty list when the draft was generated without research grounding.
+    Same 404 shape as ``/drafts/{id}`` for non-owned drafts so the auth
+    leak surface is identical.
+    """
+    snippets = store.get_draft_citations(uid, draft_id)
+    if snippets is None:
+        raise HTTPException(404, "Not found")
+    return {"draft_id": draft_id, "snippets": snippets}
 
 
 @app.get("/platforms/{platform}/adapter")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, DateTime, Float, Index, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, DateTime, Float, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -38,6 +38,12 @@ class Draft(Base):
     post_url: Mapped[str | None] = mapped_column(String, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # IDs of research snippets that fed into this draft's prompt. Stored as a
+    # JSON list rather than a join table so a single SELECT renders the draft +
+    # its citations without an extra round-trip; (user_id, url) snippet
+    # uniqueness already gives us stable IDs to reference here.
+    cited_snippet_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
@@ -56,6 +62,7 @@ class Draft(Base):
             "scheduled_at": self.scheduled_at.isoformat() if self.scheduled_at else None,
             "post_url": self.post_url,
             "error": self.error,
+            "cited_snippet_ids": list(self.cited_snippet_ids or []),
             "created_at": self.created_at.isoformat(),
         }
 
@@ -122,5 +129,64 @@ class ResearchSnippet(Base):
             "score": self.score,
             "published_at": self.published_at.isoformat() if self.published_at else None,
             "used_in_draft_id": self.used_in_draft_id,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class ResearchSubscription(Base):
+    """A saved research configuration that runs autonomously on an interval.
+
+    Turns the workbench from a manual tool into the actual compounding loop —
+    set a subscription with a few queries / RSS feeds and an interval, and a
+    cron-driven ``/research/tick`` endpoint will run them for you so banked
+    snippets stay fresh without manual clicks.
+
+    The tick endpoint (see ``store.due_subscriptions`` + ``main.research_tick``)
+    uses ``last_run_at`` to skip subs that aren't due yet — so it's safe to
+    poke every minute from a Vercel/Render cron without rate-burning Groq.
+    """
+
+    __tablename__ = "research_subscriptions"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+
+    name: Mapped[str] = mapped_column(String(128))
+    queries: Mapped[list] = mapped_column(JSON, default=list)
+    rss_feeds: Mapped[list] = mapped_column(JSON, default=list)
+    sources: Mapped[list] = mapped_column(JSON, default=lambda: ["hn", "devto", "reddit", "rss"])
+
+    # 1 = hourly, 24 = daily, 168 = weekly. Bounded server-side.
+    interval_hours: Mapped[int] = mapped_column(Integer, default=24)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    last_fetched_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        # ``due_subscriptions`` filters by (active, last_run_at) — keeping the
+        # composite index hot lets cron polls stay sub-ms even at scale.
+        Index("ix_research_subs_active_lastrun", "active", "last_run_at"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "name": self.name,
+            "queries": list(self.queries or []),
+            "rss_feeds": list(self.rss_feeds or []),
+            "sources": list(self.sources or []),
+            "interval_hours": self.interval_hours,
+            "active": self.active,
+            "last_run_at": self.last_run_at.isoformat() if self.last_run_at else None,
+            "last_fetched_count": self.last_fetched_count,
+            "last_error": self.last_error,
             "created_at": self.created_at.isoformat(),
         }

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import Draft, ResearchSnippet
+from app.models import Draft, ResearchSnippet, ResearchSubscription
 from app.research import Snippet
 
 
@@ -41,7 +41,21 @@ def build_review_checkpoint(draft: dict, confidence: float) -> dict:
     }
 
 
-def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
+def save_drafts(
+    user_id: str,
+    product: str,
+    result: dict,
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Persist drafts produced by ``agent.run``.
+
+    ``cited_snippet_ids`` records which research snippets fed the prompt for
+    *every* draft produced in this run — same set per platform because the
+    plan + research context were shared across all of them. Pass ``None`` /
+    empty for runs that didn't use research.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for platform, bundle in result["posts"].items():
@@ -53,6 +67,7 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
                 feedback=bundle["feedback"],
                 plan=result["plan"],
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
@@ -60,8 +75,20 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
     return out
 
 
-def save_variations(user_id: str, product: str, platform: str, variations: list[dict]) -> list[dict]:
-    """Save N variation drafts (from agent.variations()) for a single platform."""
+def save_variations(
+    user_id: str,
+    product: str,
+    platform: str,
+    variations: list[dict],
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Save N variation drafts (from agent.variations()) for a single platform.
+
+    ``cited_snippet_ids`` is shared across all variations — the research
+    context is the same set of signals, the variations differ only by angle.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for v in variations:
@@ -73,11 +100,33 @@ def save_variations(user_id: str, product: str, platform: str, variations: list[
                 feedback=v.get("angle"),  # store the angle in 'feedback' for visibility
                 plan=None,
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
             out.append(d.to_dict())
     return out
+
+
+def get_draft_citations(user_id: str, draft_id: str) -> list[dict] | None:
+    """Return the snippet rows cited by a draft, or ``None`` if the draft
+    doesn't belong to ``user_id`` (auth failure looks like 404)."""
+    with session_scope() as s:
+        d = s.get(Draft, draft_id)
+        if d is None or d.user_id != user_id:
+            return None
+        ids = list(d.cited_snippet_ids or [])
+        if not ids:
+            return []
+        # Single SELECT — preserve the order they were saved by re-sorting on
+        # the original list rather than the DB's natural order.
+        rows = list(
+            s.scalars(
+                select(ResearchSnippet).where(ResearchSnippet.id.in_(ids))
+            )
+        )
+        by_id = {r.id: r for r in rows}
+        return [by_id[i].to_dict() for i in ids if i in by_id]
 
 
 def list_drafts(user_id: str, status: str | None = None) -> list[dict]:
@@ -307,3 +356,162 @@ def mark_snippets_used(user_id: str, snippet_ids: list[str], draft_id: str) -> i
             row.used_in_draft_id = draft_id
             count += 1
     return count
+
+
+# ---------------------------------------------------------------------------
+# Research subscriptions — saved configs that the tick endpoint runs on cron.
+# ---------------------------------------------------------------------------
+
+
+# Server-side bounds on interval — keeps Groq quota predictable and stops a
+# user from configuring a 30s loop that hammers HN/Reddit.
+MIN_INTERVAL_HOURS = 1
+MAX_INTERVAL_HOURS = 24 * 7  # weekly is the longest we offer
+
+
+def create_subscription(
+    user_id: str,
+    *,
+    name: str,
+    queries: list[str],
+    rss_feeds: list[str],
+    sources: list[str] | None = None,
+    interval_hours: int = 24,
+    active: bool = True,
+) -> dict:
+    if not 1 <= len(name) <= 128:
+        raise ValueError("name must be 1-128 chars")
+    if not queries and not rss_feeds:
+        raise ValueError("subscription must have at least one query or rss_feed")
+    if not MIN_INTERVAL_HOURS <= interval_hours <= MAX_INTERVAL_HOURS:
+        raise ValueError(
+            f"interval_hours must be between {MIN_INTERVAL_HOURS} and {MAX_INTERVAL_HOURS}"
+        )
+    with session_scope() as s:
+        sub = ResearchSubscription(
+            user_id=user_id,
+            name=name,
+            queries=list(queries),
+            rss_feeds=list(rss_feeds),
+            sources=list(sources or ["hn", "devto", "reddit", "rss"]),
+            interval_hours=interval_hours,
+            active=active,
+        )
+        s.add(sub)
+        s.flush()
+        return sub.to_dict()
+
+
+def list_subscriptions(user_id: str) -> list[dict]:
+    with session_scope() as s:
+        stmt = (
+            select(ResearchSubscription)
+            .where(ResearchSubscription.user_id == user_id)
+            .order_by(ResearchSubscription.created_at.desc())
+        )
+        return [row.to_dict() for row in s.scalars(stmt)]
+
+
+def update_subscription(
+    user_id: str,
+    sub_id: str,
+    *,
+    name: str | None = None,
+    queries: list[str] | None = None,
+    rss_feeds: list[str] | None = None,
+    sources: list[str] | None = None,
+    interval_hours: int | None = None,
+    active: bool | None = None,
+) -> dict | None:
+    """Partial update — only the fields explicitly passed are written.
+
+    Returns the patched row, or ``None`` if it doesn't belong to ``user_id``.
+    """
+    if interval_hours is not None and not (
+        MIN_INTERVAL_HOURS <= interval_hours <= MAX_INTERVAL_HOURS
+    ):
+        raise ValueError(
+            f"interval_hours must be between {MIN_INTERVAL_HOURS} and {MAX_INTERVAL_HOURS}"
+        )
+    with session_scope() as s:
+        sub = s.get(ResearchSubscription, sub_id)
+        if sub is None or sub.user_id != user_id:
+            return None
+        if name is not None:
+            if not 1 <= len(name) <= 128:
+                raise ValueError("name must be 1-128 chars")
+            sub.name = name
+        if queries is not None:
+            sub.queries = list(queries)
+        if rss_feeds is not None:
+            sub.rss_feeds = list(rss_feeds)
+        if sources is not None:
+            sub.sources = list(sources)
+        if interval_hours is not None:
+            sub.interval_hours = interval_hours
+        if active is not None:
+            sub.active = active
+        # Validate post-patch — guards against an empty subscription after
+        # the user clears both lists in the UI.
+        if not sub.queries and not sub.rss_feeds:
+            raise ValueError("subscription must have at least one query or rss_feed")
+        s.flush()
+        return sub.to_dict()
+
+
+def delete_subscription(user_id: str, sub_id: str) -> bool:
+    with session_scope() as s:
+        sub = s.get(ResearchSubscription, sub_id)
+        if sub is None or sub.user_id != user_id:
+            return False
+        s.delete(sub)
+        return True
+
+
+def due_subscriptions(*, user_id: str | None = None, now: datetime | None = None) -> list[dict]:
+    """Return active subscriptions whose ``last_run_at`` is older than ``interval_hours``.
+
+    Pass ``user_id=None`` from a cron tick to fan out across every user; pass
+    a value from a per-user manual tick. Sub rows that have never run
+    (``last_run_at IS NULL``) are always considered due.
+    """
+    now = now or datetime.now(timezone.utc)
+    with session_scope() as s:
+        stmt = select(ResearchSubscription).where(ResearchSubscription.active.is_(True))
+        if user_id is not None:
+            stmt = stmt.where(ResearchSubscription.user_id == user_id)
+        out: list[dict] = []
+        for sub in s.scalars(stmt):
+            if sub.last_run_at is None:
+                out.append(sub.to_dict())
+                continue
+            # Treat naive timestamps as UTC — sqlite drops the tz on the way
+            # back out of storage even though we wrote a tz-aware value.
+            last = (
+                sub.last_run_at.replace(tzinfo=timezone.utc)
+                if sub.last_run_at.tzinfo is None
+                else sub.last_run_at
+            )
+            if now - last >= timedelta(hours=sub.interval_hours):
+                out.append(sub.to_dict())
+        return out
+
+
+def mark_subscription_run(
+    sub_id: str,
+    *,
+    fetched: int,
+    error: str | None = None,
+    when: datetime | None = None,
+) -> dict | None:
+    """Record a tick — bump ``last_run_at`` so the next due check skips this row."""
+    when = when or datetime.now(timezone.utc)
+    with session_scope() as s:
+        sub = s.get(ResearchSubscription, sub_id)
+        if sub is None:
+            return None
+        sub.last_run_at = when
+        sub.last_fetched_count = fetched
+        sub.last_error = error
+        s.flush()
+        return sub.to_dict()

--- a/backend/migrations/003_research_subscriptions.sql
+++ b/backend/migrations/003_research_subscriptions.sql
@@ -1,0 +1,28 @@
+-- Research subscriptions — saved query configurations that run on an interval.
+-- See app/research.py + main.research_tick for how this drives the autonomous loop.
+
+CREATE TABLE IF NOT EXISTS research_subscriptions (
+  id                   TEXT PRIMARY KEY,
+  user_id              TEXT NOT NULL,
+  name                 VARCHAR(128) NOT NULL,
+  queries              JSONB NOT NULL DEFAULT '[]'::jsonb,
+  rss_feeds            JSONB NOT NULL DEFAULT '[]'::jsonb,
+  sources              JSONB NOT NULL DEFAULT '["hn","devto","reddit","rss"]'::jsonb,
+  interval_hours       INTEGER NOT NULL DEFAULT 24,
+  active               BOOLEAN NOT NULL DEFAULT TRUE,
+  last_run_at          TIMESTAMPTZ,
+  last_fetched_count   INTEGER,
+  last_error           TEXT,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_research_subs_user_id          ON research_subscriptions (user_id);
+CREATE INDEX IF NOT EXISTS ix_research_subs_active           ON research_subscriptions (active);
+CREATE INDEX IF NOT EXISTS ix_research_subs_active_lastrun   ON research_subscriptions (active, last_run_at);
+
+-- Optional Supabase RLS:
+-- ALTER TABLE research_subscriptions ENABLE ROW LEVEL SECURITY;
+-- CREATE POLICY research_subs_owner ON research_subscriptions
+--   USING (user_id::uuid = auth.uid())
+--   WITH CHECK (user_id::uuid = auth.uid());

--- a/backend/migrations/004_draft_citations.sql
+++ b/backend/migrations/004_draft_citations.sql
@@ -1,0 +1,6 @@
+-- Add citation tracking to drafts: which research snippets fed into each draft.
+-- Stored as JSONB list of snippet ids rather than a join table so a single
+-- SELECT renders the draft + its citations without an extra round-trip.
+
+ALTER TABLE drafts
+  ADD COLUMN IF NOT EXISTS cited_snippet_ids JSONB;

--- a/backend/tests/test_agent_suggest.py
+++ b/backend/tests/test_agent_suggest.py
@@ -1,0 +1,75 @@
+"""Tests for ``SocialAgent.suggest_research_queries``.
+
+Groq is mocked at the ``_chat`` boundary — every model call funnels through
+that one method, so monkeypatching it covers all paths without spinning up
+the real client.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.agent import SocialAgent
+
+
+def _agent_with_chat_returning(monkeypatch, payload):
+    """Build a SocialAgent whose ``_chat`` returns ``payload`` (dict → JSON-str)."""
+    agent = SocialAgent.__new__(SocialAgent)  # skip __init__ → no Groq() construction
+    agent.client = None  # type: ignore[assignment]
+    agent.model = "test-model"
+    monkeypatch.setattr(agent, "_chat", lambda *a, **kw: json.dumps(payload))
+    return agent
+
+
+def test_suggest_returns_strings(monkeypatch):
+    agent = _agent_with_chat_returning(
+        monkeypatch,
+        {"queries": ["ai agents", "content automation", "indie hackers", "llm tooling", "devrel"]},
+    )
+    out = agent.suggest_research_queries("a product description that's long enough", n=5)
+    assert out == ["ai agents", "content automation", "indie hackers", "llm tooling", "devrel"]
+
+
+def test_suggest_dedupes_case_insensitive(monkeypatch):
+    agent = _agent_with_chat_returning(
+        monkeypatch,
+        {"queries": ["AI Agents", "ai agents", "  AI agents  ", "content automation"]},
+    )
+    out = agent.suggest_research_queries("p" * 20, n=5)
+    # First-seen wins on dedup; trim is applied; only two distinct phrases survive.
+    assert out == ["AI Agents", "content automation"]
+
+
+def test_suggest_drops_non_strings_and_blanks(monkeypatch):
+    agent = _agent_with_chat_returning(
+        monkeypatch,
+        {"queries": ["good one", "", "   ", {"nested": "obj"}, 42, "another good one"]},
+    )
+    out = agent.suggest_research_queries("p" * 20, n=5)
+    assert out == ["good one", "another good one"]
+
+
+def test_suggest_caps_at_n(monkeypatch):
+    agent = _agent_with_chat_returning(
+        monkeypatch,
+        {"queries": [f"q{i}" for i in range(20)]},
+    )
+    out = agent.suggest_research_queries("p" * 20, n=3)
+    assert out == ["q0", "q1", "q2"]
+
+
+def test_suggest_n_bounds():
+    agent = SocialAgent.__new__(SocialAgent)
+    agent.client = None  # type: ignore[assignment]
+    agent.model = "test-model"
+    with pytest.raises(ValueError):
+        agent.suggest_research_queries("p" * 20, n=0)
+    with pytest.raises(ValueError):
+        agent.suggest_research_queries("p" * 20, n=11)
+
+
+def test_suggest_handles_missing_queries_key(monkeypatch):
+    agent = _agent_with_chat_returning(monkeypatch, {})
+    assert agent.suggest_research_queries("p" * 20, n=5) == []

--- a/backend/tests/test_draft_citations.py
+++ b/backend/tests/test_draft_citations.py
@@ -1,0 +1,164 @@
+"""Tests for draft citation tracking — end-to-end via TestClient.
+
+Covers:
+  * cited_snippet_ids gets stamped on every draft from /generate (not just
+    the first), so the per-platform attribution is correct.
+  * /drafts/{id}/citations returns the snippets, ordered by save sequence.
+  * Auth boundary: owners-only access on the citations endpoint.
+  * Drafts produced without research return an empty list.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import main, store
+from app.research import Snippet
+
+
+def _agent_returning(monkeypatch, plan_dict, drafts_per_platform="d"):
+    """Patch SocialAgent.run so /generate returns deterministic content."""
+
+    def fake_run(self, product, platforms, *, research_context=None):
+        return {
+            "plan": plan_dict,
+            "posts": {
+                p: {
+                    "draft": "raw",
+                    "feedback": "LGTM",
+                    "final": f"{drafts_per_platform}-{p}",
+                }
+                for p in platforms
+            },
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", fake_run)
+
+
+def test_generate_with_research_attributes_to_every_draft(monkeypatch):
+    """The bug we're fixing: /generate with research used to mark only the
+    first draft as 'used' — leaving the other 14 platform drafts with no
+    audit trail. After the fix, every draft carries the same cited list."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank some snippets so the research path has data to surface.
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/1", title="t1", score=0.9),
+            Snippet(source="reddit", url="https://e.com/2", title="t2", score=0.7),
+        ],
+    )
+
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x", "linkedin"], "use_research": True},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["research_used"] == 2
+    # Every draft must carry the full cited list — not just the first.
+    cited_lists = [d["cited_snippet_ids"] for d in body["drafts"]]
+    assert len(cited_lists) == 2
+    assert all(len(c) == 2 for c in cited_lists)
+    assert cited_lists[0] == cited_lists[1]
+
+
+def test_generate_without_research_leaves_citations_empty(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": False},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert drafts[0]["cited_snippet_ids"] == []
+
+
+def test_citations_endpoint_returns_snippets_in_save_order(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank in a specific order. ``top_snippets_for_agent`` returns by score
+    # desc, so URL 2 (score 0.95) will be cited before URL 1 (score 0.5).
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/low", title="low", score=0.5),
+            Snippet(source="reddit", url="https://e.com/high", title="high", score=0.95),
+        ],
+    )
+
+    gen = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": True},
+    )
+    draft_id = gen.json()["drafts"][0]["id"]
+
+    res = client.get(f"/drafts/{draft_id}/citations")
+    assert res.status_code == 200
+    body = res.json()
+    titles = [s["title"] for s in body["snippets"]]
+    assert titles == ["high", "low"]
+
+
+def test_citations_endpoint_404_for_unknown_draft():
+    client = TestClient(main.app)
+    res = client.get("/drafts/does-not-exist/citations")
+    assert res.status_code == 404
+
+
+def test_citations_endpoint_owners_only(monkeypatch):
+    """Citations must enforce the same auth boundary as /drafts/{id}."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+
+    # Manually create a draft owned by a *different* user. We poke the store
+    # directly because TestClient is anchored to the dev-mode user.
+    fake_result = {
+        "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+        "posts": {"x": {"draft": "r", "feedback": "f", "final": "f"}},
+    }
+    drafts = store.save_drafts("other-user", "p" * 20, fake_result)
+    other_id = drafts[0]["id"]
+
+    client = TestClient(main.app)  # auths as the dev-mode user, not "other-user"
+    res = client.get(f"/drafts/{other_id}/citations")
+    assert res.status_code == 404
+
+
+def test_variations_with_research_carries_citations(monkeypatch):
+    def fake_variations(self, product, platform, n=5, *, research_context=None):
+        return [{"angle": f"angle-{i}", "content": f"c-{i}"} for i in range(n)]
+
+    monkeypatch.setattr(main.SocialAgent, "variations", fake_variations)
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    store.upsert_snippets(
+        uid, [Snippet(source="hn", url="https://e.com/v", title="v", score=0.5)]
+    )
+
+    res = client.post(
+        "/variations",
+        json={"product": "a sample product blurb", "platform": "x", "count": 3, "use_research": True},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert len(drafts) == 3
+    assert all(len(d["cited_snippet_ids"]) == 1 for d in drafts)

--- a/backend/tests/test_main_tick.py
+++ b/backend/tests/test_main_tick.py
@@ -1,0 +1,177 @@
+"""End-to-end test for the /research/tick flow using FastAPI's TestClient.
+
+We mock ``run_research`` so the test never touches the network — it just
+verifies the orchestration: due subs run, recently-run subs are skipped,
+and the response shape matches the contract the UI consumes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app import main, store
+from app.research import Snippet
+
+
+def _client(monkeypatch):
+    """Build a TestClient with auth + research mocked.
+
+    ``current_user`` defaults to dev mode in app.auth, so a fresh session
+    sees a stable test user — no header juggling needed.
+    """
+    fake_snippets = [
+        Snippet(source="hn", url=f"https://e.com/{i}", title=f"t{i}", score=0.5)
+        for i in range(3)
+    ]
+    monkeypatch.setattr(main, "run_research", lambda req: list(fake_snippets))
+    return TestClient(main.app)
+
+
+def _uid(client: TestClient) -> str:
+    return client.get("/me").json()["user_id"]
+
+
+def test_tick_runs_due_subscriptions(monkeypatch):
+    client = _client(monkeypatch)
+    uid = _uid(client)
+
+    # Two subs — one due, one already-run-recently.
+    fresh = store.create_subscription(
+        uid, name="fresh", queries=["agents"], rss_feeds=[], interval_hours=1
+    )
+    recent = store.create_subscription(
+        uid, name="recent", queries=["other"], rss_feeds=[], interval_hours=24
+    )
+    store.mark_subscription_run(recent["id"], fetched=5)  # marks last_run_at = now
+
+    res = client.post("/research/tick")
+    assert res.status_code == 200
+    body = res.json()
+    ran_ids = sorted(r["id"] for r in body["ran"])
+    assert ran_ids == [fresh["id"]]  # only the fresh one
+
+    # The fresh sub now has last_run_at populated.
+    after = store.list_subscriptions(uid)
+    by_id = {s["id"]: s for s in after}
+    assert by_id[fresh["id"]]["last_run_at"] is not None
+    assert by_id[fresh["id"]]["last_fetched_count"] == 3
+    assert by_id[fresh["id"]]["last_error"] is None
+
+
+def test_tick_records_run_error(monkeypatch):
+    client = TestClient(main.app)
+    uid = _uid(client)
+    store.create_subscription(
+        uid, name="busted", queries=["x"], rss_feeds=[], interval_hours=1
+    )
+
+    def boom(_req):
+        raise RuntimeError("upstream down")
+
+    monkeypatch.setattr(main, "run_research", boom)
+
+    res = client.post("/research/tick")
+    assert res.status_code == 200
+    ran = res.json()["ran"]
+    assert len(ran) == 1
+    assert ran[0]["fetched"] == 0
+    assert ran[0]["error"] == "upstream down"
+
+
+def test_subscription_crud_endpoints(monkeypatch):
+    client = TestClient(main.app)
+    uid = _uid(client)
+
+    # Create
+    res = client.post(
+        "/research/subscriptions",
+        json={"name": "Sub A", "queries": ["a"], "interval_hours": 6},
+    )
+    assert res.status_code == 201
+    sub = res.json()
+    assert sub["queries"] == ["a"]
+
+    # List
+    res = client.get("/research/subscriptions")
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+    # Patch
+    res = client.patch(f"/research/subscriptions/{sub['id']}", json={"active": False})
+    assert res.status_code == 200
+    assert res.json()["active"] is False
+
+    # Reject patch that empties both lists
+    res = client.patch(
+        f"/research/subscriptions/{sub['id']}",
+        json={"queries": [], "rss_feeds": []},
+    )
+    assert res.status_code == 400
+
+    # Delete
+    res = client.delete(f"/research/subscriptions/{sub['id']}")
+    assert res.status_code == 200
+    assert client.get("/research/subscriptions").json() == []
+
+    # 404 after delete
+    res = client.delete(f"/research/subscriptions/{sub['id']}")
+    assert res.status_code == 404
+
+
+def test_subscription_create_rejects_empty():
+    client = TestClient(main.app)
+    res = client.post("/research/subscriptions", json={"name": "x"})
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /research/tick/all — service-auth fan-out for cron
+# ---------------------------------------------------------------------------
+
+
+def test_tick_all_403_when_secret_unset(monkeypatch):
+    monkeypatch.delenv("RESEARCH_TICK_SECRET", raising=False)
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all", headers={"X-Tick-Secret": "anything"})
+    assert res.status_code == 403
+    assert "disabled" in res.json()["detail"].lower()
+
+
+def test_tick_all_403_on_wrong_secret(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "the-right-one")
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all", headers={"X-Tick-Secret": "wrong"})
+    assert res.status_code == 403
+
+
+def test_tick_all_403_when_header_missing(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "the-right-one")
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all")
+    assert res.status_code == 403
+
+
+def test_tick_all_runs_across_users(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "service-cron-token")
+    client = _client(monkeypatch)
+
+    # Two subs, two distinct users — both due (never run).
+    sub_a = store.create_subscription(
+        "user-alpha", name="alpha", queries=["q"], rss_feeds=[], interval_hours=1
+    )
+    sub_b = store.create_subscription(
+        "user-beta", name="beta", queries=["q"], rss_feeds=[], interval_hours=1
+    )
+
+    res = client.post(
+        "/research/tick/all", headers={"X-Tick-Secret": "service-cron-token"}
+    )
+    assert res.status_code == 200
+    body = res.json()
+    user_ids = sorted(r["user_id"] for r in body["ran"])
+    assert user_ids == sorted(["user-alpha", "user-beta"])
+
+    ran_ids = sorted(r["id"] for r in body["ran"])
+    assert ran_ids == sorted([sub_a["id"], sub_b["id"]])

--- a/backend/tests/test_store_subscriptions.py
+++ b/backend/tests/test_store_subscriptions.py
@@ -1,0 +1,133 @@
+"""Tests for research-subscription store helpers (sqlite in-memory)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import store
+
+
+def _create(user="user1", **kw):
+    defaults = dict(
+        name="My sub",
+        queries=["ai agents"],
+        rss_feeds=[],
+        interval_hours=24,
+        active=True,
+    )
+    defaults.update(kw)
+    return store.create_subscription(user, **defaults)
+
+
+def test_create_and_list():
+    sub = _create()
+    assert sub["queries"] == ["ai agents"]
+    assert sub["interval_hours"] == 24
+    assert sub["active"] is True
+    assert sub["last_run_at"] is None
+
+    rows = store.list_subscriptions("user1")
+    assert len(rows) == 1
+    assert rows[0]["id"] == sub["id"]
+
+
+def test_create_rejects_empty_queries_and_feeds():
+    with pytest.raises(ValueError):
+        store.create_subscription("user1", name="x", queries=[], rss_feeds=[])
+
+
+def test_create_rejects_bad_interval():
+    with pytest.raises(ValueError):
+        store.create_subscription(
+            "user1", name="x", queries=["q"], rss_feeds=[], interval_hours=0
+        )
+    with pytest.raises(ValueError):
+        store.create_subscription(
+            "user1", name="x", queries=["q"], rss_feeds=[], interval_hours=24 * 7 + 1
+        )
+
+
+def test_update_partial_only_writes_passed_fields():
+    sub = _create()
+    patched = store.update_subscription("user1", sub["id"], active=False)
+    assert patched is not None
+    assert patched["active"] is False
+    assert patched["name"] == "My sub"  # unchanged
+    assert patched["queries"] == ["ai agents"]
+
+
+def test_update_rejects_clearing_both_lists():
+    sub = _create()
+    with pytest.raises(ValueError):
+        store.update_subscription("user1", sub["id"], queries=[], rss_feeds=[])
+
+
+def test_update_404_for_other_users_row():
+    sub = _create(user="user1")
+    assert store.update_subscription("user2", sub["id"], active=False) is None
+
+
+def test_delete_owners_only():
+    sub = _create(user="user1")
+    assert store.delete_subscription("user2", sub["id"]) is False
+    assert store.delete_subscription("user1", sub["id"]) is True
+    assert store.list_subscriptions("user1") == []
+
+
+def test_due_includes_never_run():
+    sub = _create()
+    due = store.due_subscriptions(user_id="user1")
+    assert [d["id"] for d in due] == [sub["id"]]
+
+
+def test_due_skips_recently_run():
+    sub = _create(interval_hours=24)
+    # Mark as just run.
+    store.mark_subscription_run(sub["id"], fetched=3)
+    due = store.due_subscriptions(user_id="user1")
+    assert due == []
+
+
+def test_due_re_includes_after_interval_elapses():
+    sub = _create(interval_hours=1)
+    # Pretend it ran 2 hours ago.
+    past = datetime.now(timezone.utc) - timedelta(hours=2)
+    store.mark_subscription_run(sub["id"], fetched=0, when=past)
+    due = store.due_subscriptions(user_id="user1")
+    assert [d["id"] for d in due] == [sub["id"]]
+
+
+def test_due_skips_inactive():
+    sub = _create(active=False)
+    assert store.due_subscriptions(user_id="user1") == []
+    # Re-activate and it shows up:
+    store.update_subscription("user1", sub["id"], active=True)
+    assert len(store.due_subscriptions(user_id="user1")) == 1
+
+
+def test_due_filters_by_user():
+    a = _create(user="user1")
+    b = _create(user="user2")
+    user1_due = store.due_subscriptions(user_id="user1")
+    user2_due = store.due_subscriptions(user_id="user2")
+    assert [d["id"] for d in user1_due] == [a["id"]]
+    assert [d["id"] for d in user2_due] == [b["id"]]
+
+
+def test_due_global_returns_all_users_when_no_filter():
+    a = _create(user="user1")
+    b = _create(user="user2")
+    all_due = store.due_subscriptions()
+    ids = sorted(d["id"] for d in all_due)
+    assert ids == sorted([a["id"], b["id"]])
+
+
+def test_mark_run_records_error():
+    sub = _create()
+    out = store.mark_subscription_run(sub["id"], fetched=0, error="boom")
+    assert out is not None
+    assert out["last_error"] == "boom"
+    assert out["last_fetched_count"] == 0
+    assert out["last_run_at"] is not None

--- a/docs/RESEARCH_LOOP.md
+++ b/docs/RESEARCH_LOOP.md
@@ -1,0 +1,206 @@
+# Research loop — operator's guide
+
+Fanout's research loop pulls live signals (HN, Dev.to, Reddit, RSS) and folds them into the agent's prompt so drafts can reference what's actually being discussed today, not just the static product blurb.
+
+This doc walks the loop end-to-end — what the pieces are, how to wire them, and how to verify each step is doing what you expect.
+
+## At a glance
+
+```
+   ┌────────────────────┐
+   │ /research/suggest  │ ← seed queries from a product blurb (cuts cold-start)
+   └──────────┬─────────┘
+              │
+   ┌──────────▼─────────┐    ┌──────────────────────┐
+   │ /research          │ ←─ │ subscriptions + cron │
+   │ (manual / per-tick)│    │ /research/tick[/all] │
+   └──────────┬─────────┘    └──────────────────────┘
+              │ persists, deduped per (user_id, url)
+              ▼
+   ┌────────────────────┐
+   │  research_snippets │ ← scored by popularity × recency
+   └──────────┬─────────┘
+              │ top N unused fed into prompt when use_research:true
+              ▼
+   ┌────────────────────┐
+   │ /generate          │ → drafts.cited_snippet_ids points back at sources
+   │ /variations        │   exposed via /drafts/{id}/citations
+   └────────────────────┘
+```
+
+## Data model
+
+| Table                       | What it holds                                                              |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `research_snippets`         | One row per unique `(user_id, url)`. Score, source, query, dedup primitive. |
+| `research_subscriptions`    | Saved query + interval configs. `last_run_at` drives the tick scheduler.   |
+| `drafts.cited_snippet_ids`  | JSON list of snippet ids that fed each draft's prompt (closes the loop).   |
+
+Migrations live under `backend/migrations/00{2,3,4}_*.sql` — apply in order on a fresh database, or rely on SQLAlchemy `create_all` in dev.
+
+## Endpoints
+
+### Seeding queries
+
+```bash
+# What should I track for this product?
+curl -s -X POST http://localhost:8000/research/suggest \
+  -H 'content-type: application/json' \
+  -d '{"product":"Fanout — agentic content studio for indie shippers","count":5}'
+# → {"queries":["agentic content tools","indie hacker marketing","ai social media","content automation","developer tools launch"]}
+```
+
+### One-off fetch
+
+```bash
+curl -s -X POST http://localhost:8000/research \
+  -H 'content-type: application/json' \
+  -d '{
+    "queries": ["agentic content tools", "indie hacker marketing"],
+    "rss_feeds": ["https://news.ycombinator.com/rss"]
+  }'
+```
+
+### Recurring subscriptions
+
+```bash
+# Save the config; the subscription runs autonomously
+curl -s -X POST http://localhost:8000/research/subscriptions \
+  -H 'content-type: application/json' \
+  -d '{
+    "name": "Indie launch tracker",
+    "queries": ["indie hackers", "show hn launch"],
+    "rss_feeds": ["https://www.indiehackers.com/feed.xml"],
+    "interval_hours": 6
+  }'
+
+# Trigger your own due subscriptions manually
+curl -s -X POST http://localhost:8000/research/tick
+
+# Cron-driven fan-out across all users (requires X-Tick-Secret)
+curl -s -X POST http://localhost:8000/research/tick/all \
+  -H "X-Tick-Secret: ${RESEARCH_TICK_SECRET}"
+```
+
+### Generating drafts that cite signals
+
+```bash
+# Variations on a single platform
+curl -s -X POST http://localhost:8000/variations \
+  -H 'content-type: application/json' \
+  -d '{
+    "product": "Fanout — agentic content studio for indie shippers",
+    "platform": "linkedin",
+    "use_research": true
+  }'
+# → {"drafts":[{"cited_snippet_ids":["...","..."], ...}], "research_used": 8}
+
+# See exactly which signals fed a draft
+curl -s http://localhost:8000/drafts/<draft_id>/citations
+# → {"draft_id":"...","snippets":[{"source":"hn","title":"...","url":"...","score":0.71}, ...]}
+```
+
+## Wiring the cron
+
+`/research/tick/all` is the multi-user endpoint. It's gated by an `X-Tick-Secret` header that matches `RESEARCH_TICK_SECRET` in the backend env — without that env var set, the endpoint returns 403. This avoids any auth surprise: no secret, no service-auth path.
+
+A minimum viable cron is one HTTP POST per minute. The endpoint is idempotent — subscriptions that aren't due yet are skipped — so over-polling is safe.
+
+### GitHub Action (free)
+
+```yaml
+# .github/workflows/research-tick.yml
+name: research-tick
+on:
+  schedule:
+    - cron: "*/5 * * * *"   # every 5 min; tick is idempotent so this is safe
+jobs:
+  tick:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -fsS -X POST "${{ secrets.FANOUT_API_URL }}/research/tick/all" \
+            -H "X-Tick-Secret: ${{ secrets.RESEARCH_TICK_SECRET }}"
+```
+
+### Vercel cron
+
+```json
+// vercel.json
+{
+  "crons": [
+    {
+      "path": "/api/research-tick",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}
+```
+
+…and have `/api/research-tick` proxy to the backend with the header.
+
+### Render scheduled job
+
+Set the command to:
+
+```bash
+curl -fsS -X POST "$FANOUT_API_URL/research/tick/all" -H "X-Tick-Secret: $RESEARCH_TICK_SECRET"
+```
+
+Schedule it on Render's cron tab.
+
+## Scoring model
+
+Each snippet's score is `(popularity × recency)^0.5` — a geometric mean so both factors must be reasonable to score well. Recency uses an exponential half-life of 48 hours (so 2-day-old content is worth half what brand-new content is). Per-source soft-max popularity:
+
+| Source  | soft-max | Notes                                                          |
+| ------- | -------- | -------------------------------------------------------------- |
+| HN      | 200      | Roughly a respectable HN front-page item.                      |
+| Reddit  | 500      | Communities run hotter than HN — calibrate higher.             |
+| Dev.to  | 120      | Reactions are scarcer than HN points.                          |
+| RSS     | n/a      | No popularity signal — recency-only, capped at 0.7 so an HN/Reddit hit can outrank a fresh RSS item. |
+
+Comments are weighted 1.5× points/upvotes — discussion is a stronger signal than a passive vote.
+
+## Verifying the loop
+
+```bash
+# 1. seed
+curl -s -X POST http://localhost:8000/research/suggest \
+  -d '{"product":"<your blurb>","count":5}' | jq '.queries'
+
+# 2. fetch (using the suggestions)
+curl -s -X POST http://localhost:8000/research \
+  -d '{"queries":[...],"rss_feeds":[]}' | jq '.fetched'
+
+# 3. confirm snippets exist + are unused
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+
+# 4. generate; check research_used > 0
+curl -s -X POST http://localhost:8000/variations \
+  -d '{"product":"<blurb>","platform":"linkedin","use_research":true}' | jq '.research_used'
+
+# 5. confirm citations on the produced draft
+curl -s 'http://localhost:8000/drafts/<id>/citations' | jq '.snippets | length'
+
+# 6. confirm those snippets are now marked used (won't re-surface to the next /generate)
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+```
+
+If step 6 returns the same count as step 3, the citation marking didn't run — check the backend logs for the `mark_snippets_used` call site and confirm `RESEARCH_TICK_SECRET` isn't accidentally muting the path.
+
+## Common gotchas
+
+- **Empty research after `/generate`.** The agent only consumes **unused** snippets. Run `/research` again or wait for the next subscription tick.
+- **`UnknownPricingError` is a different module.** That's `agentbudget`. Fanout's research loop has no per-source pricing.
+- **Reddit 429s under the cron.** Reddit rate-limits unauthed requests. The configured User-Agent (`fanout-research/0.1`) helps, but if you hit limits, lower your subscription `interval_hours` or shrink the query list.
+- **Citations look stale.** `cited_snippet_ids` is the source of truth on each draft. The `used_in_draft_id` field on snippets is a back-compat shortcut — if you need a definitive "what fed this draft?" answer, hit `/drafts/{id}/citations`.
+
+## Where the code lives
+
+- `backend/app/research.py` — source fetchers, scoring, parallel orchestration
+- `backend/app/store.py` — snippets + subscriptions CRUD, `top_snippets_for_agent`, `mark_snippets_used`, `get_draft_citations`
+- `backend/app/main.py` — REST handlers (`/research`, `/research/suggest`, `/research/subscriptions`, `/research/tick`, `/research/tick/all`)
+- `backend/app/agent.py` — `plan` / `write` / `variations` accept `research_context` and bake it into prompts
+- `web/app/research/page.tsx` — workbench UI (suggest, fetch, subscriptions list)
+- `web/components/CitationsPill.tsx` — the per-draft "N signals" pill

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -27,6 +27,7 @@ import Marquee from "@/components/Marquee";
 import Spotlight from "@/components/Spotlight";
 import AnimatedNumber from "@/components/AnimatedNumber";
 import Typewriter from "@/components/Typewriter";
+import { CitationsPill } from "@/components/CitationsPill";
 
 export default function Home() {
   const [product, setProduct] = useState("");
@@ -435,6 +436,12 @@ export default function Home() {
                             <span className="badge bg-white/5 text-white/60 ring-1 ring-white/10">
                               {d.feedback}
                             </span>
+                          )}
+                          {d.cited_snippet_ids && d.cited_snippet_ids.length > 0 && (
+                            <CitationsPill
+                              draftId={d.id}
+                              count={d.cited_snippet_ids.length}
+                            />
                           )}
                         </div>
                         <span className="text-[11px] tabular-nums text-white/40">

--- a/web/app/research/page.tsx
+++ b/web/app/research/page.tsx
@@ -21,6 +21,7 @@ import {
   Search,
   Sparkles,
   Trash2,
+  Wand2,
 } from "lucide-react";
 import { api, ResearchSnippet, ResearchSource } from "@/lib/api";
 
@@ -43,6 +44,53 @@ export default function ResearchPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastFetched, setLastFetched] = useState<number | null>(null);
+
+  // "Suggest from product" — the model converts a product blurb into
+  // 5 short search queries. Cuts the cold-start friction for first-time
+  // users who don't know what to type.
+  const [suggestProduct, setSuggestProduct] = useState("");
+  const [suggesting, setSuggesting] = useState(false);
+  const [suggestionsApplied, setSuggestionsApplied] = useState(false);
+
+  const suggestQueries = async () => {
+    if (suggestProduct.trim().length < 10) {
+      setError("Add a product description (10+ chars) to get suggestions.");
+      return;
+    }
+    setSuggesting(true);
+    setError(null);
+    try {
+      const out = await api.research.suggest(suggestProduct.trim(), 5);
+      if (out.queries.length === 0) {
+        setError("No suggestions returned — try a more descriptive product blurb.");
+        return;
+      }
+      // Replace empty inputs first, then append the rest. This way an
+      // existing partial draft isn't trampled but we still surface the
+      // full suggestion set.
+      setQueries((prev) => {
+        const filled = [...prev];
+        let cursor = 0;
+        for (const q of out.queries) {
+          while (cursor < filled.length && filled[cursor].trim()) cursor++;
+          if (cursor < filled.length) {
+            filled[cursor] = q;
+            cursor++;
+          } else {
+            filled.push(q);
+          }
+        }
+        return filled;
+      });
+      setSuggestionsApplied(true);
+      // Brief flash — clear the "applied" indicator so the user can re-run.
+      setTimeout(() => setSuggestionsApplied(false), 2500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSuggesting(false);
+    }
+  };
 
   const refresh = async () => {
     setLoading(true);
@@ -117,6 +165,40 @@ export default function ResearchPage() {
         time you generate with <em>use research</em> on, the agent gets the top unused
         snippets folded into its planning prompt.
       </p>
+
+      {/* Suggest queries from product blurb — kills cold-start friction */}
+      <section className="rounded-xl border border-violet-400/20 bg-violet-500/[0.04] p-5 mb-4">
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <h2 className="text-sm font-semibold flex items-center gap-2">
+            <Wand2 size={14} className="text-violet-300" />
+            Don&apos;t know what to track? Suggest from your product
+          </h2>
+          {suggestionsApplied && (
+            <span className="text-xs text-emerald-300">Added 5 queries below</span>
+          )}
+        </div>
+        <div className="flex gap-2 items-stretch">
+          <textarea
+            value={suggestProduct}
+            onChange={(e) => setSuggestProduct(e.target.value)}
+            placeholder="Paste your product description — same text you'd put in the composer..."
+            rows={2}
+            className="flex-1 rounded-lg bg-black/40 border border-white/10 px-3 py-2 text-sm focus:outline-none focus:border-violet-400/50 resize-none"
+          />
+          <button
+            onClick={suggestQueries}
+            disabled={suggesting || suggestProduct.trim().length < 10}
+            className="rounded-lg border border-violet-400/30 bg-violet-500/15 px-3 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1.5 whitespace-nowrap"
+          >
+            {suggesting ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Sparkles size={12} />
+            )}
+            {suggesting ? "Thinking..." : "Suggest 5"}
+          </button>
+        </div>
+      </section>
 
       <section className="rounded-xl border border-white/10 bg-white/[0.03] p-5 mb-8">
         <h2 className="text-sm font-semibold mb-4 flex items-center gap-2">

--- a/web/app/research/page.tsx
+++ b/web/app/research/page.tsx
@@ -13,17 +13,22 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   ArrowLeft,
+  Bookmark,
+  Clock,
   ExternalLink,
   Loader2,
   Newspaper,
+  Pause,
+  Play,
   Plus,
   RefreshCw,
   Search,
   Sparkles,
   Trash2,
   Wand2,
+  Zap,
 } from "lucide-react";
-import { api, ResearchSnippet, ResearchSource } from "@/lib/api";
+import { api, ResearchSnippet, ResearchSource, ResearchSubscription } from "@/lib/api";
 
 const ALL_SOURCES: ResearchSource[] = ["hn", "devto", "reddit", "rss"];
 
@@ -51,6 +56,100 @@ export default function ResearchPage() {
   const [suggestProduct, setSuggestProduct] = useState("");
   const [suggesting, setSuggesting] = useState(false);
   const [suggestionsApplied, setSuggestionsApplied] = useState(false);
+
+  // Subscriptions — saved configs that the /research/tick endpoint runs on
+  // a cron. Loaded alongside snippets; updates are optimistic-by-refresh.
+  const [subs, setSubs] = useState<ResearchSubscription[]>([]);
+  const [subsLoading, setSubsLoading] = useState(true);
+  const [subName, setSubName] = useState("");
+  const [subInterval, setSubInterval] = useState(24);
+  const [savingSub, setSavingSub] = useState(false);
+  const [ticking, setTicking] = useState(false);
+  const [tickResult, setTickResult] = useState<string | null>(null);
+
+  const refreshSubs = async () => {
+    setSubsLoading(true);
+    try {
+      setSubs(await api.research.subscriptions.list());
+    } catch {
+      // Older backend → leave the panel empty rather than error-flashing.
+      setSubs([]);
+    } finally {
+      setSubsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshSubs();
+  }, []);
+
+  const saveCurrentAsSubscription = async () => {
+    const cleanQueries = queries.map((q) => q.trim()).filter(Boolean);
+    const cleanFeeds = feeds.map((f) => f.trim()).filter(Boolean);
+    if (cleanQueries.length === 0 && cleanFeeds.length === 0) {
+      setError("Add at least one query or RSS feed before saving.");
+      return;
+    }
+    if (!subName.trim()) {
+      setError("Name your subscription so you can find it later.");
+      return;
+    }
+    setSavingSub(true);
+    setError(null);
+    try {
+      await api.research.subscriptions.create({
+        name: subName.trim(),
+        queries: cleanQueries,
+        rss_feeds: cleanFeeds,
+        interval_hours: subInterval,
+      });
+      setSubName("");
+      await refreshSubs();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingSub(false);
+    }
+  };
+
+  const toggleSubActive = async (sub: ResearchSubscription) => {
+    try {
+      await api.research.subscriptions.update(sub.id, { active: !sub.active });
+      await refreshSubs();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const deleteSub = async (sub: ResearchSubscription) => {
+    try {
+      await api.research.subscriptions.remove(sub.id);
+      await refreshSubs();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const runTick = async () => {
+    setTicking(true);
+    setError(null);
+    setTickResult(null);
+    try {
+      const out = await api.research.tick();
+      const totalFetched = out.ran.reduce((acc, r) => acc + r.fetched, 0);
+      setTickResult(
+        out.ran.length === 0
+          ? "Nothing was due."
+          : `Ran ${out.ran.length} subscription${out.ran.length === 1 ? "" : "s"}, fetched ${totalFetched} snippet${totalFetched === 1 ? "" : "s"}.`
+      );
+      await Promise.all([refresh(), refreshSubs()]);
+      setTimeout(() => setTickResult(null), 4000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTicking(false);
+    }
+  };
 
   const suggestQueries = async () => {
     if (suggestProduct.trim().length < 10) {
@@ -285,7 +384,7 @@ export default function ResearchPage() {
           </div>
         </div>
 
-        <div className="flex items-center gap-3 pt-2">
+        <div className="flex flex-wrap items-center gap-3 pt-2">
           <button
             onClick={runResearch}
             disabled={running}
@@ -294,12 +393,90 @@ export default function ResearchPage() {
             {running ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
             {running ? "Fetching..." : "Run research"}
           </button>
+
+          {/* Save the current form as a recurring subscription. Lives next to
+              the run button so the action is in the user's eyeline once they've
+              dialled in queries that work. */}
+          <div className="flex items-center gap-2 ml-auto">
+            <input
+              value={subName}
+              onChange={(e) => setSubName(e.target.value)}
+              placeholder="Subscription name"
+              className="rounded-lg bg-black/40 border border-white/10 px-2.5 py-1.5 text-xs w-44 focus:outline-none focus:border-violet-400/50"
+            />
+            <select
+              value={subInterval}
+              onChange={(e) => setSubInterval(Number(e.target.value))}
+              className="rounded-lg bg-black/40 border border-white/10 px-2 py-1.5 text-xs focus:outline-none focus:border-violet-400/50"
+            >
+              <option value={1}>every hour</option>
+              <option value={6}>every 6h</option>
+              <option value={12}>every 12h</option>
+              <option value={24}>daily</option>
+              <option value={168}>weekly</option>
+            </select>
+            <button
+              onClick={saveCurrentAsSubscription}
+              disabled={savingSub}
+              className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium hover:bg-white/5 disabled:opacity-50 inline-flex items-center gap-1.5"
+            >
+              {savingSub ? <Loader2 size={12} className="animate-spin" /> : <Bookmark size={12} />}
+              Save as subscription
+            </button>
+          </div>
+
           {lastFetched != null && !running && (
             <span className="text-xs text-white/50">
               Last run: {lastFetched} snippets fetched
             </span>
           )}
         </div>
+      </section>
+
+      {/* Subscriptions panel */}
+      <section className="rounded-xl border border-white/10 bg-white/[0.03] p-5 mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold flex items-center gap-2">
+            <Clock size={14} className="text-violet-300" />
+            Recurring subscriptions
+            <span className="text-xs text-white/50 font-normal">
+              {subs.filter((s) => s.active).length} active
+            </span>
+          </h2>
+          <button
+            onClick={runTick}
+            disabled={ticking || subs.filter((s) => s.active).length === 0}
+            className="rounded-lg border border-violet-400/30 bg-violet-500/15 px-3 py-1.5 text-xs font-medium hover:bg-violet-500/25 disabled:opacity-40 inline-flex items-center gap-1.5"
+          >
+            {ticking ? <Loader2 size={12} className="animate-spin" /> : <Zap size={12} />}
+            {ticking ? "Running..." : "Run due now"}
+          </button>
+        </div>
+
+        {tickResult && (
+          <div className="rounded-lg border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200 mb-3">
+            {tickResult}
+          </div>
+        )}
+
+        {subsLoading ? (
+          <div className="text-xs text-white/40 text-center py-4">Loading...</div>
+        ) : subs.length === 0 ? (
+          <p className="text-xs text-white/50 text-center py-4">
+            No subscriptions yet. Configure queries above and save them with a name to run them automatically.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {subs.map((s) => (
+              <SubscriptionRow
+                key={s.id}
+                sub={s}
+                onToggle={() => void toggleSubActive(s)}
+                onDelete={() => void deleteSub(s)}
+              />
+            ))}
+          </ul>
+        )}
       </section>
 
       <section>
@@ -398,6 +575,89 @@ function SnippetRow({ snippet }: { snippet: ResearchSnippet }) {
       {snippet.snippet && (
         <p className="text-xs text-white/60 mt-1 line-clamp-2">{snippet.snippet}</p>
       )}
+    </li>
+  );
+}
+
+function SubscriptionRow({
+  sub,
+  onToggle,
+  onDelete,
+}: {
+  sub: ResearchSubscription;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const intervalLabel =
+    sub.interval_hours === 1
+      ? "every hour"
+      : sub.interval_hours === 24
+      ? "daily"
+      : sub.interval_hours === 168
+      ? "weekly"
+      : `every ${sub.interval_hours}h`;
+
+  return (
+    <li
+      className={`rounded-lg border border-white/[0.08] bg-black/20 px-3 py-2.5 ${
+        sub.active ? "" : "opacity-60"
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium truncate">{sub.name}</span>
+            <span className="text-[10px] font-mono text-white/40 uppercase">
+              {intervalLabel}
+            </span>
+            {!sub.active && (
+              <span className="text-[10px] font-mono text-amber-300/80 uppercase">paused</span>
+            )}
+          </div>
+          <div className="text-xs text-white/50 truncate mt-0.5">
+            {sub.queries.length > 0 && <>{sub.queries.join(" · ")}</>}
+            {sub.queries.length > 0 && sub.rss_feeds.length > 0 && <> · </>}
+            {sub.rss_feeds.length > 0 && (
+              <span className="text-white/40">
+                {sub.rss_feeds.length} feed{sub.rss_feeds.length === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+          {(sub.last_run_at || sub.last_error) && (
+            <div className="text-[10px] text-white/40 mt-1 font-mono">
+              {sub.last_error ? (
+                <span className="text-rose-300/80">last error: {sub.last_error}</span>
+              ) : (
+                <>
+                  last run{" "}
+                  <time dateTime={sub.last_run_at!}>
+                    {new Date(sub.last_run_at!).toLocaleString()}
+                  </time>
+                  {sub.last_fetched_count != null && <> · {sub.last_fetched_count} fetched</>}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={onToggle}
+            className="p-1.5 rounded text-white/50 hover:text-white hover:bg-white/5"
+            aria-label={sub.active ? "Pause subscription" : "Resume subscription"}
+            title={sub.active ? "Pause" : "Resume"}
+          >
+            {sub.active ? <Pause size={12} /> : <Play size={12} />}
+          </button>
+          <button
+            onClick={onDelete}
+            className="p-1.5 rounded text-white/40 hover:text-rose-300 hover:bg-rose-500/10"
+            aria-label="Delete subscription"
+            title="Delete"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
     </li>
   );
 }

--- a/web/components/CitationsPill.tsx
+++ b/web/components/CitationsPill.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * Tiny pill that surfaces "this draft was grounded by N research signals."
+ * Lazy-fetches the snippet titles on first open to avoid an N+1 stampede when
+ * many cards mount at once — only drafts the user actually inspects pay the
+ * round-trip.
+ */
+
+import { useState } from "react";
+import { ExternalLink, Loader2, Newspaper } from "lucide-react";
+import { api, ResearchSnippet } from "@/lib/api";
+
+const SOURCE_LABEL: Record<string, string> = {
+  hn: "HN",
+  devto: "Dev.to",
+  reddit: "Reddit",
+  rss: "RSS",
+};
+
+export function CitationsPill({
+  draftId,
+  count,
+}: {
+  draftId: string;
+  count: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [snippets, setSnippets] = useState<ResearchSnippet[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  if (count <= 0) return null;
+
+  const toggle = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // don't trip the parent card's select-toggle
+    const next = !open;
+    setOpen(next);
+    if (next && !loaded && !loading) {
+      setLoading(true);
+      setError(null);
+      try {
+        const out = await api.citations(draftId);
+        setSnippets(out.snippets);
+        setLoaded(true);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={toggle}
+        className="inline-flex items-center gap-1 rounded-full border border-violet-400/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-200 hover:bg-violet-500/20 transition-colors"
+        aria-expanded={open}
+        aria-label={`${count} research signal${count === 1 ? "" : "s"} grounded this draft`}
+      >
+        <Newspaper size={10} />
+        {count} signal{count === 1 ? "" : "s"}
+      </button>
+
+      {open && (
+        <div
+          className="absolute z-30 right-0 mt-1.5 w-72 rounded-xl border border-white/10 bg-black/95 p-3 shadow-2xl backdrop-blur-xl"
+          // Stop click propagation on the popover itself so users can interact
+          // with links / scrollbars without toggling the parent card.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="text-[10px] font-mono uppercase tracking-wider text-white/40 mb-2">
+            Grounded by
+          </div>
+          {loading ? (
+            <div className="text-xs text-white/50 flex items-center gap-1.5">
+              <Loader2 size={11} className="animate-spin" /> loading...
+            </div>
+          ) : error ? (
+            <div className="text-xs text-rose-300">{error}</div>
+          ) : snippets.length === 0 ? (
+            // The snippet may have been deleted from the bank since the draft
+            // was generated. Don't show a misleading "0" — explain what's up.
+            <div className="text-xs text-white/50">
+              Citations no longer in your bank.
+            </div>
+          ) : (
+            <ul className="space-y-1.5">
+              {snippets.map((s) => (
+                <li key={s.id} className="text-xs">
+                  <a
+                    href={s.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-start gap-1.5 text-white/85 hover:text-violet-200 leading-tight"
+                  >
+                    <span className="text-[9px] font-mono uppercase text-white/40 mt-0.5 shrink-0">
+                      {SOURCE_LABEL[s.source] ?? s.source}
+                    </span>
+                    <span className="line-clamp-2 flex-1">{s.title}</span>
+                    <ExternalLink size={9} className="opacity-50 mt-0.5 shrink-0" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -87,6 +87,11 @@ export const api = {
       const tail = qs.toString();
       return request<ResearchSnippet[]>(`/research${tail ? `?${tail}` : ""}`);
     },
+    suggest: (product: string, count = 5) =>
+      request<{ queries: string[] }>("/research/suggest", {
+        method: "POST",
+        body: JSON.stringify({ product, count }),
+      }),
   },
 };
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -65,6 +65,10 @@ export const api = {
     }),
   cancelSchedule: (id: string) =>
     request<Draft>(`/drafts/${id}/schedule`, { method: "DELETE" }),
+  citations: (id: string) =>
+    request<{ draft_id: string; snippets: ResearchSnippet[] }>(
+      `/drafts/${id}/citations`
+    ),
   me: () => request<{ user_id: string }>("/me"),
 
   // --- research loop ---------------------------------------------------------
@@ -92,6 +96,44 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ product, count }),
       }),
+
+    subscriptions: {
+      list: () => request<ResearchSubscription[]>("/research/subscriptions"),
+      create: (input: {
+        name: string;
+        queries?: string[];
+        rss_feeds?: string[];
+        sources?: ResearchSource[];
+        interval_hours?: number;
+        active?: boolean;
+      }) =>
+        request<ResearchSubscription>("/research/subscriptions", {
+          method: "POST",
+          body: JSON.stringify(input),
+        }),
+      update: (id: string, patch: Partial<{
+        name: string;
+        queries: string[];
+        rss_feeds: string[];
+        sources: ResearchSource[];
+        interval_hours: number;
+        active: boolean;
+      }>) =>
+        request<ResearchSubscription>(`/research/subscriptions/${id}`, {
+          method: "PATCH",
+          body: JSON.stringify(patch),
+        }),
+      remove: (id: string) =>
+        request<{ deleted: string }>(`/research/subscriptions/${id}`, {
+          method: "DELETE",
+        }),
+    },
+
+    tick: () =>
+      request<{ ran: { id: string; name: string; fetched: number; error: string | null }[] }>(
+        "/research/tick",
+        { method: "POST" }
+      ),
   },
 };
 
@@ -122,6 +164,9 @@ export type Draft = {
   scheduled_at: string | null;
   post_url?: string | null;
   error?: string | null;
+  // IDs of research snippets that fed this draft's prompt. Empty when the
+  // draft was generated without research grounding.
+  cited_snippet_ids?: string[];
   created_at: string;
 };
 
@@ -138,5 +183,20 @@ export type ResearchSnippet = {
   score: number;
   published_at: string | null;
   used_in_draft_id: string | null;
+  created_at: string;
+};
+
+export type ResearchSubscription = {
+  id: string;
+  user_id: string;
+  name: string;
+  queries: string[];
+  rss_feeds: string[];
+  sources: ResearchSource[];
+  interval_hours: number;
+  active: boolean;
+  last_run_at: string | null;
+  last_fetched_count: number | null;
+  last_error: string | null;
   created_at: string;
 };


### PR DESCRIPTION
Stacks on **#29**. Merge order: #28 → #29 → this.

Without this the workbench is an empty form — first-time users land there without an obvious answer to \"what should I type?\" This adds a one-click \"Suggest 5\" button: paste the same blurb you'd put in the composer, get back 5 short search queries (2-5 words each, mixing audience / problem / adjacent-space terms) pre-filled into the query inputs.

## What ships

- \`SocialAgent.suggest_research_queries\` — Groq JSON-mode call. Defensive parsing: drops non-strings, dedupes case-insensitively, caps at \`n\`.
- \`POST /research/suggest\` — auth-gated so anon callers can't burn Groq quota.
- \`lib/api.ts\`: \`research.suggest(product, count?)\`
- \`/research\` page: a violet-tinted suggest panel above the run-research form. Brief \"Added 5 queries below\" flash on apply. Existing partial drafts in the query inputs aren't trampled — suggestions fill empty slots first, then append.
- 6 pytest tests covering the dedup / non-string / cap / bounds paths

## Test plan

- [x] \`pytest\` — 25/25 passing (19 prior + 6 new)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx next build\` clean, \`/research\` route +0.5 kB
- [ ] CI green
- [ ] Manual: paste product blurb on \`/research\`, click \"Suggest 5\", verify queries pre-fill the form, hit \"Run research\"