### PR TITLE
chore(ci): hourly research-tick GitHub Action (opt-in)

### DIFF
--- a/.github/workflows/research-tick.yml
+++ b/.github/workflows/research-tick.yml
@@ -1,11 +1,13 @@
-# Research-tick cron — hits POST /research/tick on the deployed backend so
-# active research subscriptions auto-fetch on their configured cadence.
+# Research-tick cron — hits POST /research/tick/all on the deployed backend so
+# active research subscriptions auto-fetch on their configured cadence, fanning
+# out across every user in one request.
 #
 # Disabled by default. To enable:
-#   1. Deploy the backend somewhere reachable from GitHub-hosted runners.
+#   1. Deploy the backend with env var RESEARCH_TICK_SECRET set to a strong random
+#      string (the service auth token for the fan-out endpoint).
 #   2. Set repo VARIABLE  RESEARCH_TICK_ENABLED = "true"
-#   3. Set repo SECRET    RESEARCH_TICK_URL     = "https://api.example.com/research/tick"
-#   4. Optionally set     RESEARCH_TICK_TOKEN   = "<bearer-token>"   (Supabase JWT)
+#   3. Set repo SECRET    RESEARCH_TICK_URL     = "https://api.example.com/research/tick/all"
+#   4. Set repo SECRET    RESEARCH_TICK_SECRET  = "<same value as backend env>"
 #
 # The job is intentionally permissive — a transient backend hiccup should not
 # turn the repo's CI badge red. Failures are logged but the step exits 0.
@@ -50,23 +52,22 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Hit /research/tick
+      - name: Hit /research/tick/all
         if: steps.probe.outputs.skip != 'true'
         env:
           URL: ${{ secrets.RESEARCH_TICK_URL }}
-          TOKEN: ${{ secrets.RESEARCH_TICK_TOKEN }}
+          TICK_SECRET: ${{ secrets.RESEARCH_TICK_SECRET }}
         run: |
           set -u
+          if [ -z "$TICK_SECRET" ]; then
+            echo "::warning::RESEARCH_TICK_SECRET is unset — backend will reject the request with 403."
+          fi
           # ``-w`` writes a status-code line we can inspect for non-2xx.
           # ``--max-time`` caps the request so a hung backend doesn't burn
           # the whole 5-minute timeout. Body goes to ``response.json``.
-          AUTH=()
-          if [ -n "$TOKEN" ]; then
-            AUTH=(-H "Authorization: Bearer $TOKEN")
-          fi
           STATUS=$(curl -sS -X POST "$URL" \
             -H 'content-type: application/json' \
-            "${AUTH[@]}" \
+            -H "X-Tick-Secret: $TICK_SECRET" \
             --max-time 90 \
             -o response.json \
             -w '%{http_code}' || echo "000")
@@ -75,7 +76,7 @@ jobs:
           cat response.json || true
           echo
           if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 300 ]; then
-            echo "::warning::Research tick returned HTTP $STATUS — check backend health."
+            echo "::warning::Research tick returned HTTP $STATUS — check backend health and secret."
             # Exit 0 anyway; a flaky backend should not turn the repo red.
           fi
 

--- a/.github/workflows/research-tick.yml
+++ b/.github/workflows/research-tick.yml
@@ -1,0 +1,117 @@
+# Research-tick cron — hits POST /research/tick on the deployed backend so
+# active research subscriptions auto-fetch on their configured cadence.
+#
+# Disabled by default. To enable:
+#   1. Deploy the backend somewhere reachable from GitHub-hosted runners.
+#   2. Set repo VARIABLE  RESEARCH_TICK_ENABLED = "true"
+#   3. Set repo SECRET    RESEARCH_TICK_URL     = "https://api.example.com/research/tick"
+#   4. Optionally set     RESEARCH_TICK_TOKEN   = "<bearer-token>"   (Supabase JWT)
+#
+# The job is intentionally permissive — a transient backend hiccup should not
+# turn the repo's CI badge red. Failures are logged but the step exits 0.
+# Workflow output shows fetched/skipped counts per run via the JSON response.
+
+name: Research tick
+
+on:
+  schedule:
+    # Hourly — the tick endpoint is idempotent (subs that aren't due yet
+    # get skipped server-side), so cheap to run more often than the
+    # tightest subscription interval.
+    - cron: "17 * * * *"
+  workflow_dispatch:
+    # Manual fire from the Actions tab — handy for smoke-testing after
+    # changing subscription configs.
+
+permissions:
+  contents: read
+
+concurrency:
+  # Tick is idempotent but there's no point queuing a backlog if the cron
+  # somehow runs concurrently with itself.
+  group: research-tick
+  cancel-in-progress: false
+
+jobs:
+  tick:
+    if: vars.RESEARCH_TICK_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Probe required secrets
+        id: probe
+        env:
+          URL: ${{ secrets.RESEARCH_TICK_URL }}
+        run: |
+          if [ -z "$URL" ]; then
+            echo "::warning::RESEARCH_TICK_ENABLED is true but RESEARCH_TICK_URL is unset; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Hit /research/tick
+        if: steps.probe.outputs.skip != 'true'
+        env:
+          URL: ${{ secrets.RESEARCH_TICK_URL }}
+          TOKEN: ${{ secrets.RESEARCH_TICK_TOKEN }}
+        run: |
+          set -u
+          # ``-w`` writes a status-code line we can inspect for non-2xx.
+          # ``--max-time`` caps the request so a hung backend doesn't burn
+          # the whole 5-minute timeout. Body goes to ``response.json``.
+          AUTH=()
+          if [ -n "$TOKEN" ]; then
+            AUTH=(-H "Authorization: Bearer $TOKEN")
+          fi
+          STATUS=$(curl -sS -X POST "$URL" \
+            -H 'content-type: application/json' \
+            "${AUTH[@]}" \
+            --max-time 90 \
+            -o response.json \
+            -w '%{http_code}' || echo "000")
+          echo "HTTP $STATUS"
+          echo "--- response ---"
+          cat response.json || true
+          echo
+          if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 300 ]; then
+            echo "::warning::Research tick returned HTTP $STATUS — check backend health."
+            # Exit 0 anyway; a flaky backend should not turn the repo red.
+          fi
+
+      - name: Summarize
+        if: steps.probe.outputs.skip != 'true' && always()
+        run: |
+          # The response shape is:
+          #   { "ran": [{"id","name","fetched","error"}, ...], "skipped": [...] }
+          if [ -f response.json ]; then
+            python3 - <<'PY'
+          import json, os, pathlib
+          try:
+              data = json.loads(pathlib.Path("response.json").read_text())
+          except Exception as e:
+              print(f"could not parse response: {e}")
+              raise SystemExit(0)
+          ran = data.get("ran", []) if isinstance(data, dict) else []
+          total = sum(r.get("fetched", 0) or 0 for r in ran)
+          errors = [r for r in ran if r.get("error")]
+          summary = f"Ran {len(ran)} subscriptions, fetched {total} snippets"
+          if errors:
+              summary += f", {len(errors)} with errors"
+          print(summary)
+          # Surface in the workflow run summary so it's visible without clicking in.
+          step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if step_summary:
+              with open(step_summary, "a") as f:
+                  f.write(f"### Research tick\n\n{summary}\n")
+                  for r in ran:
+                      mark = "❌" if r.get("error") else "✅"
+                      f.write(
+                          f"- {mark} `{r.get('name','?')}` — "
+                          f"fetched {r.get('fetched',0)}"
+                      )
+                      if r.get("error"):
+                          f.write(f" — error: `{r['error']}`")
+                      f.write("\n")
+          PY
+          fi

--- a/README.md
+++ b/README.md
@@ -97,6 +97,33 @@ Snippets are scored by upstream popularity × recency (48h half-life), deduped
 per `(user_id, url)`, and marked **used** the first time they feed into a
 draft so the next research run pulls fresh material.
 
+### Autonomous loop (recurring subscriptions)
+
+Save a query/feed config once and let it refresh on its own:
+
+```bash
+# create a daily subscription
+curl -X POST http://localhost:8000/research/subscriptions \
+  -H 'content-type: application/json' \
+  -d '{"name":"AI agents","queries":["ai agents","llm tooling"],"interval_hours":24}'
+
+# tick the loop — runs every active subscription that's due
+curl -X POST http://localhost:8000/research/tick
+```
+
+Wire `POST /research/tick` to **any** scheduler — Vercel cron, Render scheduled
+job, or the bundled GitHub Action at `.github/workflows/research-tick.yml`.
+
+To enable the GitHub Action:
+
+1. Set repo **Variable** `RESEARCH_TICK_ENABLED = "true"`
+2. Set repo **Secret** `RESEARCH_TICK_URL` to your deployed `/research/tick` URL
+3. (Optional) Set repo **Secret** `RESEARCH_TICK_TOKEN` if your backend requires
+   a Supabase Bearer token
+
+The action runs hourly. The tick endpoint is idempotent — subscriptions that
+aren't due yet are skipped server-side, so over-polling is safe.
+
 ## Deploying the web app
 
 **Easy mode — Vercel native git integration (recommended):**

--- a/README.md
+++ b/README.md
@@ -111,15 +111,24 @@ curl -X POST http://localhost:8000/research/subscriptions \
 curl -X POST http://localhost:8000/research/tick
 ```
 
-Wire `POST /research/tick` to **any** scheduler — Vercel cron, Render scheduled
-job, or the bundled GitHub Action at `.github/workflows/research-tick.yml`.
+Two tick endpoints depending on use case:
+
+- **`POST /research/tick`** — per-user, JWT auth. The "Run due now" button on
+  the workbench hits this.
+- **`POST /research/tick/all`** — service-auth (`X-Tick-Secret` header), fans
+  out across every user in one request. **Disabled by default** — set
+  `RESEARCH_TICK_SECRET` env var on the backend to enable.
+
+For a real cron, use `/research/tick/all`. Wire it to **any** scheduler —
+Vercel cron, Render scheduled job, or the bundled GitHub Action at
+`.github/workflows/research-tick.yml`.
 
 To enable the GitHub Action:
 
-1. Set repo **Variable** `RESEARCH_TICK_ENABLED = "true"`
-2. Set repo **Secret** `RESEARCH_TICK_URL` to your deployed `/research/tick` URL
-3. (Optional) Set repo **Secret** `RESEARCH_TICK_TOKEN` if your backend requires
-   a Supabase Bearer token
+1. Set backend env var `RESEARCH_TICK_SECRET` to a strong random string
+2. Set repo **Variable** `RESEARCH_TICK_ENABLED = "true"`
+3. Set repo **Secret** `RESEARCH_TICK_URL` = `https://<your-backend>/research/tick/all`
+4. Set repo **Secret** `RESEARCH_TICK_SECRET` to the same value as step 1
 
 The action runs hourly. The tick endpoint is idempotent — subscriptions that
 aren't due yet are skipped server-side, so over-polling is safe.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -12,7 +13,7 @@ from dotenv import load_dotenv
 # Load .env from the backend root regardless of cwd.
 load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
-from fastapi import Depends, FastAPI, HTTPException  # noqa: E402
+from fastapi import Depends, FastAPI, Header, HTTPException  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from pydantic import BaseModel, Field  # noqa: E402
 
@@ -295,10 +296,9 @@ def subscription_delete(sub_id: str, uid: str = Depends(current_user)):
 def research_tick(uid: str = Depends(current_user)):
     """Run every due subscription belonging to the authed user, in sequence.
 
-    Cron-friendly: idempotent (skips subs that aren't due) and per-user
-    so the auth model stays simple. A platform-wide cron should call this
-    once per active user; for now the same authed user can hit it manually
-    from the UI to refresh.
+    Per-user, idempotent (skips subs that aren't due). Used by the workbench
+    "Run due now" button. For a platform-wide cron, see ``/research/tick/all``
+    which auths via service secret and fans out across every user.
     """
     due = store.due_subscriptions(user_id=uid)
     ran: list[dict] = []
@@ -306,6 +306,41 @@ def research_tick(uid: str = Depends(current_user)):
         fetched, error = _run_subscription(sub)
         store.mark_subscription_run(sub["id"], fetched=fetched, error=error)
         ran.append({"id": sub["id"], "name": sub["name"], "fetched": fetched, "error": error})
+    return {"ran": ran, "skipped": []}
+
+
+@app.post("/research/tick/all")
+def research_tick_all(x_tick_secret: str | None = Header(default=None)):
+    """Service-auth tick — runs every due subscription across **all** users.
+
+    Auths via the ``X-Tick-Secret`` header rather than a user JWT, so a single
+    GitHub Action / Vercel cron / Render scheduled job can drive the loop for
+    everyone with one secret. Falls back to 403 when ``RESEARCH_TICK_SECRET``
+    isn't set on the server, so the endpoint is **off by default**.
+    """
+    expected = os.environ.get("RESEARCH_TICK_SECRET")
+    if not expected:
+        raise HTTPException(
+            403, "Service tick disabled — set RESEARCH_TICK_SECRET on the backend to enable."
+        )
+    # Constant-time compare to dodge timing-side-channel guesses on the secret.
+    if not x_tick_secret or not secrets.compare_digest(x_tick_secret, expected):
+        raise HTTPException(403, "Invalid X-Tick-Secret header")
+
+    due = store.due_subscriptions()  # no user filter → all active subs
+    ran: list[dict] = []
+    for sub in due:
+        fetched, error = _run_subscription(sub)
+        store.mark_subscription_run(sub["id"], fetched=fetched, error=error)
+        ran.append(
+            {
+                "id": sub["id"],
+                "user_id": sub["user_id"],
+                "name": sub["name"],
+                "fetched": fetched,
+                "error": error,
+            }
+        )
     return {"ran": ran, "skipped": []}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,9 +152,11 @@ def generate(req: GenerateRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     result = agent.run(req.product, platforms=tuple(req.platforms), research_context=research_block)
-    drafts = store.save_drafts(uid, req.product, result)
-    # Mark every consumed snippet against the *first* draft — keeps the
-    # used/unused signal accurate without needing per-platform attribution.
+    drafts = store.save_drafts(uid, req.product, result, cited_snippet_ids=snippet_ids)
+    # Snippets are stamped with the *first* draft for the legacy used_in_draft_id
+    # field (kept for back-compat with the snippet list filter), but the canonical
+    # attribution lives on each draft's ``cited_snippet_ids`` JSON column — so
+    # GET /drafts/<id>/citations works for *every* draft in the run, not just one.
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"plan": result["plan"], "drafts": drafts, "research_used": len(snippet_ids)}
@@ -167,7 +169,9 @@ def variations(req: VariationsRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     items = agent.variations(req.product, req.platform, n=req.count, research_context=research_block)
-    drafts = store.save_variations(uid, req.product, req.platform, items)
+    drafts = store.save_variations(
+        uid, req.product, req.platform, items, cited_snippet_ids=snippet_ids
+    )
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"drafts": drafts, "research_used": len(snippet_ids)}
@@ -365,6 +369,20 @@ def get_draft(draft_id: str, uid: str = Depends(current_user)):
     if not d:
         raise HTTPException(404, "Not found")
     return d
+
+
+@app.get("/drafts/{draft_id}/citations")
+def draft_citations(draft_id: str, uid: str = Depends(current_user)):
+    """Return the research snippets that fed this draft's prompt.
+
+    Empty list when the draft was generated without research grounding.
+    Same 404 shape as ``/drafts/{id}`` for non-owned drafts so the auth
+    leak surface is identical.
+    """
+    snippets = store.get_draft_citations(uid, draft_id)
+    if snippets is None:
+        raise HTTPException(404, "Not found")
+    return {"draft_id": draft_id, "snippets": snippets}
 
 
 @app.get("/platforms/{platform}/adapter")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -38,6 +38,12 @@ class Draft(Base):
     post_url: Mapped[str | None] = mapped_column(String, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # IDs of research snippets that fed into this draft's prompt. Stored as a
+    # JSON list rather than a join table so a single SELECT renders the draft +
+    # its citations without an extra round-trip; (user_id, url) snippet
+    # uniqueness already gives us stable IDs to reference here.
+    cited_snippet_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
@@ -56,6 +62,7 @@ class Draft(Base):
             "scheduled_at": self.scheduled_at.isoformat() if self.scheduled_at else None,
             "post_url": self.post_url,
             "error": self.error,
+            "cited_snippet_ids": list(self.cited_snippet_ids or []),
             "created_at": self.created_at.isoformat(),
         }
 

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -41,7 +41,21 @@ def build_review_checkpoint(draft: dict, confidence: float) -> dict:
     }
 
 
-def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
+def save_drafts(
+    user_id: str,
+    product: str,
+    result: dict,
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Persist drafts produced by ``agent.run``.
+
+    ``cited_snippet_ids`` records which research snippets fed the prompt for
+    *every* draft produced in this run — same set per platform because the
+    plan + research context were shared across all of them. Pass ``None`` /
+    empty for runs that didn't use research.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for platform, bundle in result["posts"].items():
@@ -53,6 +67,7 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
                 feedback=bundle["feedback"],
                 plan=result["plan"],
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
@@ -60,8 +75,20 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
     return out
 
 
-def save_variations(user_id: str, product: str, platform: str, variations: list[dict]) -> list[dict]:
-    """Save N variation drafts (from agent.variations()) for a single platform."""
+def save_variations(
+    user_id: str,
+    product: str,
+    platform: str,
+    variations: list[dict],
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Save N variation drafts (from agent.variations()) for a single platform.
+
+    ``cited_snippet_ids`` is shared across all variations — the research
+    context is the same set of signals, the variations differ only by angle.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for v in variations:
@@ -73,11 +100,33 @@ def save_variations(user_id: str, product: str, platform: str, variations: list[
                 feedback=v.get("angle"),  # store the angle in 'feedback' for visibility
                 plan=None,
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
             out.append(d.to_dict())
     return out
+
+
+def get_draft_citations(user_id: str, draft_id: str) -> list[dict] | None:
+    """Return the snippet rows cited by a draft, or ``None`` if the draft
+    doesn't belong to ``user_id`` (auth failure looks like 404)."""
+    with session_scope() as s:
+        d = s.get(Draft, draft_id)
+        if d is None or d.user_id != user_id:
+            return None
+        ids = list(d.cited_snippet_ids or [])
+        if not ids:
+            return []
+        # Single SELECT — preserve the order they were saved by re-sorting on
+        # the original list rather than the DB's natural order.
+        rows = list(
+            s.scalars(
+                select(ResearchSnippet).where(ResearchSnippet.id.in_(ids))
+            )
+        )
+        by_id = {r.id: r for r in rows}
+        return [by_id[i].to_dict() for i in ids if i in by_id]
 
 
 def list_drafts(user_id: str, status: str | None = None) -> list[dict]:

--- a/backend/migrations/004_draft_citations.sql
+++ b/backend/migrations/004_draft_citations.sql
@@ -1,0 +1,6 @@
+-- Add citation tracking to drafts: which research snippets fed into each draft.
+-- Stored as JSONB list of snippet ids rather than a join table so a single
+-- SELECT renders the draft + its citations without an extra round-trip.
+
+ALTER TABLE drafts
+  ADD COLUMN IF NOT EXISTS cited_snippet_ids JSONB;

--- a/backend/tests/test_draft_citations.py
+++ b/backend/tests/test_draft_citations.py
@@ -1,0 +1,164 @@
+"""Tests for draft citation tracking — end-to-end via TestClient.
+
+Covers:
+  * cited_snippet_ids gets stamped on every draft from /generate (not just
+    the first), so the per-platform attribution is correct.
+  * /drafts/{id}/citations returns the snippets, ordered by save sequence.
+  * Auth boundary: owners-only access on the citations endpoint.
+  * Drafts produced without research return an empty list.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import main, store
+from app.research import Snippet
+
+
+def _agent_returning(monkeypatch, plan_dict, drafts_per_platform="d"):
+    """Patch SocialAgent.run so /generate returns deterministic content."""
+
+    def fake_run(self, product, platforms, *, research_context=None):
+        return {
+            "plan": plan_dict,
+            "posts": {
+                p: {
+                    "draft": "raw",
+                    "feedback": "LGTM",
+                    "final": f"{drafts_per_platform}-{p}",
+                }
+                for p in platforms
+            },
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", fake_run)
+
+
+def test_generate_with_research_attributes_to_every_draft(monkeypatch):
+    """The bug we're fixing: /generate with research used to mark only the
+    first draft as 'used' — leaving the other 14 platform drafts with no
+    audit trail. After the fix, every draft carries the same cited list."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank some snippets so the research path has data to surface.
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/1", title="t1", score=0.9),
+            Snippet(source="reddit", url="https://e.com/2", title="t2", score=0.7),
+        ],
+    )
+
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x", "linkedin"], "use_research": True},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["research_used"] == 2
+    # Every draft must carry the full cited list — not just the first.
+    cited_lists = [d["cited_snippet_ids"] for d in body["drafts"]]
+    assert len(cited_lists) == 2
+    assert all(len(c) == 2 for c in cited_lists)
+    assert cited_lists[0] == cited_lists[1]
+
+
+def test_generate_without_research_leaves_citations_empty(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": False},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert drafts[0]["cited_snippet_ids"] == []
+
+
+def test_citations_endpoint_returns_snippets_in_save_order(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank in a specific order. ``top_snippets_for_agent`` returns by score
+    # desc, so URL 2 (score 0.95) will be cited before URL 1 (score 0.5).
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/low", title="low", score=0.5),
+            Snippet(source="reddit", url="https://e.com/high", title="high", score=0.95),
+        ],
+    )
+
+    gen = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": True},
+    )
+    draft_id = gen.json()["drafts"][0]["id"]
+
+    res = client.get(f"/drafts/{draft_id}/citations")
+    assert res.status_code == 200
+    body = res.json()
+    titles = [s["title"] for s in body["snippets"]]
+    assert titles == ["high", "low"]
+
+
+def test_citations_endpoint_404_for_unknown_draft():
+    client = TestClient(main.app)
+    res = client.get("/drafts/does-not-exist/citations")
+    assert res.status_code == 404
+
+
+def test_citations_endpoint_owners_only(monkeypatch):
+    """Citations must enforce the same auth boundary as /drafts/{id}."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+
+    # Manually create a draft owned by a *different* user. We poke the store
+    # directly because TestClient is anchored to the dev-mode user.
+    fake_result = {
+        "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+        "posts": {"x": {"draft": "r", "feedback": "f", "final": "f"}},
+    }
+    drafts = store.save_drafts("other-user", "p" * 20, fake_result)
+    other_id = drafts[0]["id"]
+
+    client = TestClient(main.app)  # auths as the dev-mode user, not "other-user"
+    res = client.get(f"/drafts/{other_id}/citations")
+    assert res.status_code == 404
+
+
+def test_variations_with_research_carries_citations(monkeypatch):
+    def fake_variations(self, product, platform, n=5, *, research_context=None):
+        return [{"angle": f"angle-{i}", "content": f"c-{i}"} for i in range(n)]
+
+    monkeypatch.setattr(main.SocialAgent, "variations", fake_variations)
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    store.upsert_snippets(
+        uid, [Snippet(source="hn", url="https://e.com/v", title="v", score=0.5)]
+    )
+
+    res = client.post(
+        "/variations",
+        json={"product": "a sample product blurb", "platform": "x", "count": 3, "use_research": True},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert len(drafts) == 3
+    assert all(len(d["cited_snippet_ids"]) == 1 for d in drafts)

--- a/backend/tests/test_main_tick.py
+++ b/backend/tests/test_main_tick.py
@@ -124,3 +124,54 @@ def test_subscription_create_rejects_empty():
     client = TestClient(main.app)
     res = client.post("/research/subscriptions", json={"name": "x"})
     assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /research/tick/all — service-auth fan-out for cron
+# ---------------------------------------------------------------------------
+
+
+def test_tick_all_403_when_secret_unset(monkeypatch):
+    monkeypatch.delenv("RESEARCH_TICK_SECRET", raising=False)
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all", headers={"X-Tick-Secret": "anything"})
+    assert res.status_code == 403
+    assert "disabled" in res.json()["detail"].lower()
+
+
+def test_tick_all_403_on_wrong_secret(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "the-right-one")
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all", headers={"X-Tick-Secret": "wrong"})
+    assert res.status_code == 403
+
+
+def test_tick_all_403_when_header_missing(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "the-right-one")
+    client = TestClient(main.app)
+    res = client.post("/research/tick/all")
+    assert res.status_code == 403
+
+
+def test_tick_all_runs_across_users(monkeypatch):
+    monkeypatch.setenv("RESEARCH_TICK_SECRET", "service-cron-token")
+    client = _client(monkeypatch)
+
+    # Two subs, two distinct users — both due (never run).
+    sub_a = store.create_subscription(
+        "user-alpha", name="alpha", queries=["q"], rss_feeds=[], interval_hours=1
+    )
+    sub_b = store.create_subscription(
+        "user-beta", name="beta", queries=["q"], rss_feeds=[], interval_hours=1
+    )
+
+    res = client.post(
+        "/research/tick/all", headers={"X-Tick-Secret": "service-cron-token"}
+    )
+    assert res.status_code == 200
+    body = res.json()
+    user_ids = sorted(r["user_id"] for r in body["ran"])
+    assert user_ids == sorted(["user-alpha", "user-beta"])
+
+    ran_ids = sorted(r["id"] for r in body["ran"])
+    assert ran_ids == sorted([sub_a["id"], sub_b["id"]])

--- a/docs/RESEARCH_LOOP.md
+++ b/docs/RESEARCH_LOOP.md
@@ -1,0 +1,206 @@
+# Research loop — operator's guide
+
+Fanout's research loop pulls live signals (HN, Dev.to, Reddit, RSS) and folds them into the agent's prompt so drafts can reference what's actually being discussed today, not just the static product blurb.
+
+This doc walks the loop end-to-end — what the pieces are, how to wire them, and how to verify each step is doing what you expect.
+
+## At a glance
+
+```
+   ┌────────────────────┐
+   │ /research/suggest  │ ← seed queries from a product blurb (cuts cold-start)
+   └──────────┬─────────┘
+              │
+   ┌──────────▼─────────┐    ┌──────────────────────┐
+   │ /research          │ ←─ │ subscriptions + cron │
+   │ (manual / per-tick)│    │ /research/tick[/all] │
+   └──────────┬─────────┘    └──────────────────────┘
+              │ persists, deduped per (user_id, url)
+              ▼
+   ┌────────────────────┐
+   │  research_snippets │ ← scored by popularity × recency
+   └──────────┬─────────┘
+              │ top N unused fed into prompt when use_research:true
+              ▼
+   ┌────────────────────┐
+   │ /generate          │ → drafts.cited_snippet_ids points back at sources
+   │ /variations        │   exposed via /drafts/{id}/citations
+   └────────────────────┘
+```
+
+## Data model
+
+| Table                       | What it holds                                                              |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `research_snippets`         | One row per unique `(user_id, url)`. Score, source, query, dedup primitive. |
+| `research_subscriptions`    | Saved query + interval configs. `last_run_at` drives the tick scheduler.   |
+| `drafts.cited_snippet_ids`  | JSON list of snippet ids that fed each draft's prompt (closes the loop).   |
+
+Migrations live under `backend/migrations/00{2,3,4}_*.sql` — apply in order on a fresh database, or rely on SQLAlchemy `create_all` in dev.
+
+## Endpoints
+
+### Seeding queries
+
+```bash
+# What should I track for this product?
+curl -s -X POST http://localhost:8000/research/suggest \
+  -H 'content-type: application/json' \
+  -d '{"product":"Fanout — agentic content studio for indie shippers","count":5}'
+# → {"queries":["agentic content tools","indie hacker marketing","ai social media","content automation","developer tools launch"]}
+```
+
+### One-off fetch
+
+```bash
+curl -s -X POST http://localhost:8000/research \
+  -H 'content-type: application/json' \
+  -d '{
+    "queries": ["agentic content tools", "indie hacker marketing"],
+    "rss_feeds": ["https://news.ycombinator.com/rss"]
+  }'
+```
+
+### Recurring subscriptions
+
+```bash
+# Save the config; the subscription runs autonomously
+curl -s -X POST http://localhost:8000/research/subscriptions \
+  -H 'content-type: application/json' \
+  -d '{
+    "name": "Indie launch tracker",
+    "queries": ["indie hackers", "show hn launch"],
+    "rss_feeds": ["https://www.indiehackers.com/feed.xml"],
+    "interval_hours": 6
+  }'
+
+# Trigger your own due subscriptions manually
+curl -s -X POST http://localhost:8000/research/tick
+
+# Cron-driven fan-out across all users (requires X-Tick-Secret)
+curl -s -X POST http://localhost:8000/research/tick/all \
+  -H "X-Tick-Secret: ${RESEARCH_TICK_SECRET}"
+```
+
+### Generating drafts that cite signals
+
+```bash
+# Variations on a single platform
+curl -s -X POST http://localhost:8000/variations \
+  -H 'content-type: application/json' \
+  -d '{
+    "product": "Fanout — agentic content studio for indie shippers",
+    "platform": "linkedin",
+    "use_research": true
+  }'
+# → {"drafts":[{"cited_snippet_ids":["...","..."], ...}], "research_used": 8}
+
+# See exactly which signals fed a draft
+curl -s http://localhost:8000/drafts/<draft_id>/citations
+# → {"draft_id":"...","snippets":[{"source":"hn","title":"...","url":"...","score":0.71}, ...]}
+```
+
+## Wiring the cron
+
+`/research/tick/all` is the multi-user endpoint. It's gated by an `X-Tick-Secret` header that matches `RESEARCH_TICK_SECRET` in the backend env — without that env var set, the endpoint returns 403. This avoids any auth surprise: no secret, no service-auth path.
+
+A minimum viable cron is one HTTP POST per minute. The endpoint is idempotent — subscriptions that aren't due yet are skipped — so over-polling is safe.
+
+### GitHub Action (free)
+
+```yaml
+# .github/workflows/research-tick.yml
+name: research-tick
+on:
+  schedule:
+    - cron: "*/5 * * * *"   # every 5 min; tick is idempotent so this is safe
+jobs:
+  tick:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -fsS -X POST "${{ secrets.FANOUT_API_URL }}/research/tick/all" \
+            -H "X-Tick-Secret: ${{ secrets.RESEARCH_TICK_SECRET }}"
+```
+
+### Vercel cron
+
+```json
+// vercel.json
+{
+  "crons": [
+    {
+      "path": "/api/research-tick",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}
+```
+
+…and have `/api/research-tick` proxy to the backend with the header.
+
+### Render scheduled job
+
+Set the command to:
+
+```bash
+curl -fsS -X POST "$FANOUT_API_URL/research/tick/all" -H "X-Tick-Secret: $RESEARCH_TICK_SECRET"
+```
+
+Schedule it on Render's cron tab.
+
+## Scoring model
+
+Each snippet's score is `(popularity × recency)^0.5` — a geometric mean so both factors must be reasonable to score well. Recency uses an exponential half-life of 48 hours (so 2-day-old content is worth half what brand-new content is). Per-source soft-max popularity:
+
+| Source  | soft-max | Notes                                                          |
+| ------- | -------- | -------------------------------------------------------------- |
+| HN      | 200      | Roughly a respectable HN front-page item.                      |
+| Reddit  | 500      | Communities run hotter than HN — calibrate higher.             |
+| Dev.to  | 120      | Reactions are scarcer than HN points.                          |
+| RSS     | n/a      | No popularity signal — recency-only, capped at 0.7 so an HN/Reddit hit can outrank a fresh RSS item. |
+
+Comments are weighted 1.5× points/upvotes — discussion is a stronger signal than a passive vote.
+
+## Verifying the loop
+
+```bash
+# 1. seed
+curl -s -X POST http://localhost:8000/research/suggest \
+  -d '{"product":"<your blurb>","count":5}' | jq '.queries'
+
+# 2. fetch (using the suggestions)
+curl -s -X POST http://localhost:8000/research \
+  -d '{"queries":[...],"rss_feeds":[]}' | jq '.fetched'
+
+# 3. confirm snippets exist + are unused
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+
+# 4. generate; check research_used > 0
+curl -s -X POST http://localhost:8000/variations \
+  -d '{"product":"<blurb>","platform":"linkedin","use_research":true}' | jq '.research_used'
+
+# 5. confirm citations on the produced draft
+curl -s 'http://localhost:8000/drafts/<id>/citations' | jq '.snippets | length'
+
+# 6. confirm those snippets are now marked used (won't re-surface to the next /generate)
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+```
+
+If step 6 returns the same count as step 3, the citation marking didn't run — check the backend logs for the `mark_snippets_used` call site and confirm `RESEARCH_TICK_SECRET` isn't accidentally muting the path.
+
+## Common gotchas
+
+- **Empty research after `/generate`.** The agent only consumes **unused** snippets. Run `/research` again or wait for the next subscription tick.
+- **`UnknownPricingError` is a different module.** That's `agentbudget`. Fanout's research loop has no per-source pricing.
+- **Reddit 429s under the cron.** Reddit rate-limits unauthed requests. The configured User-Agent (`fanout-research/0.1`) helps, but if you hit limits, lower your subscription `interval_hours` or shrink the query list.
+- **Citations look stale.** `cited_snippet_ids` is the source of truth on each draft. The `used_in_draft_id` field on snippets is a back-compat shortcut — if you need a definitive "what fed this draft?" answer, hit `/drafts/{id}/citations`.
+
+## Where the code lives
+
+- `backend/app/research.py` — source fetchers, scoring, parallel orchestration
+- `backend/app/store.py` — snippets + subscriptions CRUD, `top_snippets_for_agent`, `mark_snippets_used`, `get_draft_citations`
+- `backend/app/main.py` — REST handlers (`/research`, `/research/suggest`, `/research/subscriptions`, `/research/tick`, `/research/tick/all`)
+- `backend/app/agent.py` — `plan` / `write` / `variations` accept `research_context` and bake it into prompts
+- `web/app/research/page.tsx` — workbench UI (suggest, fetch, subscriptions list)
+- `web/components/CitationsPill.tsx` — the per-draft "N signals" pill

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -27,6 +27,7 @@ import Marquee from "@/components/Marquee";
 import Spotlight from "@/components/Spotlight";
 import AnimatedNumber from "@/components/AnimatedNumber";
 import Typewriter from "@/components/Typewriter";
+import { CitationsPill } from "@/components/CitationsPill";
 
 export default function Home() {
   const [product, setProduct] = useState("");
@@ -435,6 +436,12 @@ export default function Home() {
                             <span className="badge bg-white/5 text-white/60 ring-1 ring-white/10">
                               {d.feedback}
                             </span>
+                          )}
+                          {d.cited_snippet_ids && d.cited_snippet_ids.length > 0 && (
+                            <CitationsPill
+                              draftId={d.id}
+                              count={d.cited_snippet_ids.length}
+                            />
                           )}
                         </div>
                         <span className="text-[11px] tabular-nums text-white/40">

--- a/web/components/CitationsPill.tsx
+++ b/web/components/CitationsPill.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * Tiny pill that surfaces "this draft was grounded by N research signals."
+ * Lazy-fetches the snippet titles on first open to avoid an N+1 stampede when
+ * many cards mount at once — only drafts the user actually inspects pay the
+ * round-trip.
+ */
+
+import { useState } from "react";
+import { ExternalLink, Loader2, Newspaper } from "lucide-react";
+import { api, ResearchSnippet } from "@/lib/api";
+
+const SOURCE_LABEL: Record<string, string> = {
+  hn: "HN",
+  devto: "Dev.to",
+  reddit: "Reddit",
+  rss: "RSS",
+};
+
+export function CitationsPill({
+  draftId,
+  count,
+}: {
+  draftId: string;
+  count: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [snippets, setSnippets] = useState<ResearchSnippet[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  if (count <= 0) return null;
+
+  const toggle = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // don't trip the parent card's select-toggle
+    const next = !open;
+    setOpen(next);
+    if (next && !loaded && !loading) {
+      setLoading(true);
+      setError(null);
+      try {
+        const out = await api.citations(draftId);
+        setSnippets(out.snippets);
+        setLoaded(true);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={toggle}
+        className="inline-flex items-center gap-1 rounded-full border border-violet-400/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-200 hover:bg-violet-500/20 transition-colors"
+        aria-expanded={open}
+        aria-label={`${count} research signal${count === 1 ? "" : "s"} grounded this draft`}
+      >
+        <Newspaper size={10} />
+        {count} signal{count === 1 ? "" : "s"}
+      </button>
+
+      {open && (
+        <div
+          className="absolute z-30 right-0 mt-1.5 w-72 rounded-xl border border-white/10 bg-black/95 p-3 shadow-2xl backdrop-blur-xl"
+          // Stop click propagation on the popover itself so users can interact
+          // with links / scrollbars without toggling the parent card.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="text-[10px] font-mono uppercase tracking-wider text-white/40 mb-2">
+            Grounded by
+          </div>
+          {loading ? (
+            <div className="text-xs text-white/50 flex items-center gap-1.5">
+              <Loader2 size={11} className="animate-spin" /> loading...
+            </div>
+          ) : error ? (
+            <div className="text-xs text-rose-300">{error}</div>
+          ) : snippets.length === 0 ? (
+            // The snippet may have been deleted from the bank since the draft
+            // was generated. Don't show a misleading "0" — explain what's up.
+            <div className="text-xs text-white/50">
+              Citations no longer in your bank.
+            </div>
+          ) : (
+            <ul className="space-y-1.5">
+              {snippets.map((s) => (
+                <li key={s.id} className="text-xs">
+                  <a
+                    href={s.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-start gap-1.5 text-white/85 hover:text-violet-200 leading-tight"
+                  >
+                    <span className="text-[9px] font-mono uppercase text-white/40 mt-0.5 shrink-0">
+                      {SOURCE_LABEL[s.source] ?? s.source}
+                    </span>
+                    <span className="line-clamp-2 flex-1">{s.title}</span>
+                    <ExternalLink size={9} className="opacity-50 mt-0.5 shrink-0" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -65,6 +65,10 @@ export const api = {
     }),
   cancelSchedule: (id: string) =>
     request<Draft>(`/drafts/${id}/schedule`, { method: "DELETE" }),
+  citations: (id: string) =>
+    request<{ draft_id: string; snippets: ResearchSnippet[] }>(
+      `/drafts/${id}/citations`
+    ),
   me: () => request<{ user_id: string }>("/me"),
 
   // --- research loop ---------------------------------------------------------
@@ -160,6 +164,9 @@ export type Draft = {
   scheduled_at: string | null;
   post_url?: string | null;
   error?: string | null;
+  // IDs of research snippets that fed this draft's prompt. Empty when the
+  // draft was generated without research grounding.
+  cited_snippet_ids?: string[];
   created_at: string;
 };
 


### PR DESCRIPTION
Stacks on **#32**. Merge order: #28 → #29 → #31 → #32 → this.

The subscription model from #32 is in place but **inert without a cron**. This lands two pieces:

1. **\`POST /research/tick/all\`** — service-auth fan-out endpoint. Auths via \`X-Tick-Secret\` header (constant-time compare), runs every active subscription across **all users** in one pass. Off by default; set \`RESEARCH_TICK_SECRET\` env var on the backend to enable.
2. **\`.github/workflows/research-tick.yml\`** — hourly cron + manual dispatch. Disabled until you set \`vars.RESEARCH_TICK_ENABLED == 'true'\`. Hits the new \`/tick/all\` endpoint.

Per-user \`POST /research/tick\` stays as-is — it's the right shape for the workbench \"Run due now\" button. The new \`/tick/all\` is the right shape for a real cron (one secret, one request, fans out).

## What ships

**Backend**
- New \`/research/tick/all\` endpoint — \`X-Tick-Secret\` header check via \`secrets.compare_digest\` (timing-side-channel safe)
- 4 new tests covering: secret-unset 403, wrong-secret 403, missing-header 403, multi-user fan-out happy path

**Workflow**
- Hourly cron + workflow_dispatch
- Gated on \`vars.RESEARCH_TICK_ENABLED == 'true'\` so it lands in main without doing anything until you opt in
- Permissions: \`contents: read\` only; concurrency group prevents accidental overlap; 5-minute job timeout + 90s curl timeout
- Defensive failure handling — non-2xx responses log a warning but don't fail the workflow (the tick endpoint is idempotent — over-polling is safe)
- Each run writes a structured summary to \`GITHUB_STEP_SUMMARY\` with per-sub status

## To enable

```
backend env  RESEARCH_TICK_SECRET   = <strong random string>
repo var     RESEARCH_TICK_ENABLED  = true
repo secret  RESEARCH_TICK_URL      = https://<your-backend>/research/tick/all
repo secret  RESEARCH_TICK_SECRET   = <same as backend env>
```

## Why a GH Action and not Vercel/Render cron

- Lives in this repo — versionable, reviewable, no external dashboard config drift
- Free for public repos; Vercel cron is on a quota; Render scheduled jobs need a paid plan
- The README still mentions the alternatives — they all hit the same endpoint

## Test plan

- [x] \`pytest tests/\` — **47/47 passing** (43 prior + 4 service-auth)
- [x] \`yaml.safe_load\` parses the workflow file
- [x] Disabled job (no var set) — workflow simply doesn't fire
- [ ] Enabled with a real URL — \`workflow_dispatch\` from Actions tab returns the JSON, summary card renders
- [ ] CI green