### PR TITLE
feat: per-draft citation tracking + UI pill

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,9 +152,11 @@ def generate(req: GenerateRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     result = agent.run(req.product, platforms=tuple(req.platforms), research_context=research_block)
-    drafts = store.save_drafts(uid, req.product, result)
-    # Mark every consumed snippet against the *first* draft — keeps the
-    # used/unused signal accurate without needing per-platform attribution.
+    drafts = store.save_drafts(uid, req.product, result, cited_snippet_ids=snippet_ids)
+    # Snippets are stamped with the *first* draft for the legacy used_in_draft_id
+    # field (kept for back-compat with the snippet list filter), but the canonical
+    # attribution lives on each draft's ``cited_snippet_ids`` JSON column — so
+    # GET /drafts/<id>/citations works for *every* draft in the run, not just one.
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"plan": result["plan"], "drafts": drafts, "research_used": len(snippet_ids)}
@@ -167,7 +169,9 @@ def variations(req: VariationsRequest, uid: str = Depends(current_user)):
     research_block, snippet_ids = _build_research_context(uid, enabled=req.use_research)
     agent = SocialAgent()
     items = agent.variations(req.product, req.platform, n=req.count, research_context=research_block)
-    drafts = store.save_variations(uid, req.product, req.platform, items)
+    drafts = store.save_variations(
+        uid, req.product, req.platform, items, cited_snippet_ids=snippet_ids
+    )
     if snippet_ids and drafts:
         store.mark_snippets_used(uid, snippet_ids, drafts[0]["id"])
     return {"drafts": drafts, "research_used": len(snippet_ids)}
@@ -365,6 +369,20 @@ def get_draft(draft_id: str, uid: str = Depends(current_user)):
     if not d:
         raise HTTPException(404, "Not found")
     return d
+
+
+@app.get("/drafts/{draft_id}/citations")
+def draft_citations(draft_id: str, uid: str = Depends(current_user)):
+    """Return the research snippets that fed this draft's prompt.
+
+    Empty list when the draft was generated without research grounding.
+    Same 404 shape as ``/drafts/{id}`` for non-owned drafts so the auth
+    leak surface is identical.
+    """
+    snippets = store.get_draft_citations(uid, draft_id)
+    if snippets is None:
+        raise HTTPException(404, "Not found")
+    return {"draft_id": draft_id, "snippets": snippets}
 
 
 @app.get("/platforms/{platform}/adapter")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -38,6 +38,12 @@ class Draft(Base):
     post_url: Mapped[str | None] = mapped_column(String, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # IDs of research snippets that fed into this draft's prompt. Stored as a
+    # JSON list rather than a join table so a single SELECT renders the draft +
+    # its citations without an extra round-trip; (user_id, url) snippet
+    # uniqueness already gives us stable IDs to reference here.
+    cited_snippet_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
@@ -56,6 +62,7 @@ class Draft(Base):
             "scheduled_at": self.scheduled_at.isoformat() if self.scheduled_at else None,
             "post_url": self.post_url,
             "error": self.error,
+            "cited_snippet_ids": list(self.cited_snippet_ids or []),
             "created_at": self.created_at.isoformat(),
         }
 

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -41,7 +41,21 @@ def build_review_checkpoint(draft: dict, confidence: float) -> dict:
     }
 
 
-def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
+def save_drafts(
+    user_id: str,
+    product: str,
+    result: dict,
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Persist drafts produced by ``agent.run``.
+
+    ``cited_snippet_ids`` records which research snippets fed the prompt for
+    *every* draft produced in this run — same set per platform because the
+    plan + research context were shared across all of them. Pass ``None`` /
+    empty for runs that didn't use research.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for platform, bundle in result["posts"].items():
@@ -53,6 +67,7 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
                 feedback=bundle["feedback"],
                 plan=result["plan"],
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
@@ -60,8 +75,20 @@ def save_drafts(user_id: str, product: str, result: dict) -> list[dict]:
     return out
 
 
-def save_variations(user_id: str, product: str, platform: str, variations: list[dict]) -> list[dict]:
-    """Save N variation drafts (from agent.variations()) for a single platform."""
+def save_variations(
+    user_id: str,
+    product: str,
+    platform: str,
+    variations: list[dict],
+    *,
+    cited_snippet_ids: list[str] | None = None,
+) -> list[dict]:
+    """Save N variation drafts (from agent.variations()) for a single platform.
+
+    ``cited_snippet_ids`` is shared across all variations — the research
+    context is the same set of signals, the variations differ only by angle.
+    """
+    cited = list(cited_snippet_ids or []) or None
     out = []
     with session_scope() as s:
         for v in variations:
@@ -73,11 +100,33 @@ def save_variations(user_id: str, product: str, platform: str, variations: list[
                 feedback=v.get("angle"),  # store the angle in 'feedback' for visibility
                 plan=None,
                 status="pending",
+                cited_snippet_ids=cited,
             )
             s.add(d)
             s.flush()
             out.append(d.to_dict())
     return out
+
+
+def get_draft_citations(user_id: str, draft_id: str) -> list[dict] | None:
+    """Return the snippet rows cited by a draft, or ``None`` if the draft
+    doesn't belong to ``user_id`` (auth failure looks like 404)."""
+    with session_scope() as s:
+        d = s.get(Draft, draft_id)
+        if d is None or d.user_id != user_id:
+            return None
+        ids = list(d.cited_snippet_ids or [])
+        if not ids:
+            return []
+        # Single SELECT — preserve the order they were saved by re-sorting on
+        # the original list rather than the DB's natural order.
+        rows = list(
+            s.scalars(
+                select(ResearchSnippet).where(ResearchSnippet.id.in_(ids))
+            )
+        )
+        by_id = {r.id: r for r in rows}
+        return [by_id[i].to_dict() for i in ids if i in by_id]
 
 
 def list_drafts(user_id: str, status: str | None = None) -> list[dict]:

--- a/backend/migrations/004_draft_citations.sql
+++ b/backend/migrations/004_draft_citations.sql
@@ -1,0 +1,6 @@
+-- Add citation tracking to drafts: which research snippets fed into each draft.
+-- Stored as JSONB list of snippet ids rather than a join table so a single
+-- SELECT renders the draft + its citations without an extra round-trip.
+
+ALTER TABLE drafts
+  ADD COLUMN IF NOT EXISTS cited_snippet_ids JSONB;

--- a/backend/tests/test_draft_citations.py
+++ b/backend/tests/test_draft_citations.py
@@ -1,0 +1,164 @@
+"""Tests for draft citation tracking — end-to-end via TestClient.
+
+Covers:
+  * cited_snippet_ids gets stamped on every draft from /generate (not just
+    the first), so the per-platform attribution is correct.
+  * /drafts/{id}/citations returns the snippets, ordered by save sequence.
+  * Auth boundary: owners-only access on the citations endpoint.
+  * Drafts produced without research return an empty list.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import main, store
+from app.research import Snippet
+
+
+def _agent_returning(monkeypatch, plan_dict, drafts_per_platform="d"):
+    """Patch SocialAgent.run so /generate returns deterministic content."""
+
+    def fake_run(self, product, platforms, *, research_context=None):
+        return {
+            "plan": plan_dict,
+            "posts": {
+                p: {
+                    "draft": "raw",
+                    "feedback": "LGTM",
+                    "final": f"{drafts_per_platform}-{p}",
+                }
+                for p in platforms
+            },
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", fake_run)
+
+
+def test_generate_with_research_attributes_to_every_draft(monkeypatch):
+    """The bug we're fixing: /generate with research used to mark only the
+    first draft as 'used' — leaving the other 14 platform drafts with no
+    audit trail. After the fix, every draft carries the same cited list."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank some snippets so the research path has data to surface.
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/1", title="t1", score=0.9),
+            Snippet(source="reddit", url="https://e.com/2", title="t2", score=0.7),
+        ],
+    )
+
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x", "linkedin"], "use_research": True},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["research_used"] == 2
+    # Every draft must carry the full cited list — not just the first.
+    cited_lists = [d["cited_snippet_ids"] for d in body["drafts"]]
+    assert len(cited_lists) == 2
+    assert all(len(c) == 2 for c in cited_lists)
+    assert cited_lists[0] == cited_lists[1]
+
+
+def test_generate_without_research_leaves_citations_empty(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    res = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": False},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert drafts[0]["cited_snippet_ids"] == []
+
+
+def test_citations_endpoint_returns_snippets_in_save_order(monkeypatch):
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    # Bank in a specific order. ``top_snippets_for_agent`` returns by score
+    # desc, so URL 2 (score 0.95) will be cited before URL 1 (score 0.5).
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/low", title="low", score=0.5),
+            Snippet(source="reddit", url="https://e.com/high", title="high", score=0.95),
+        ],
+    )
+
+    gen = client.post(
+        "/generate",
+        json={"product": "a sample product blurb", "platforms": ["x"], "use_research": True},
+    )
+    draft_id = gen.json()["drafts"][0]["id"]
+
+    res = client.get(f"/drafts/{draft_id}/citations")
+    assert res.status_code == 200
+    body = res.json()
+    titles = [s["title"] for s in body["snippets"]]
+    assert titles == ["high", "low"]
+
+
+def test_citations_endpoint_404_for_unknown_draft():
+    client = TestClient(main.app)
+    res = client.get("/drafts/does-not-exist/citations")
+    assert res.status_code == 404
+
+
+def test_citations_endpoint_owners_only(monkeypatch):
+    """Citations must enforce the same auth boundary as /drafts/{id}."""
+    _agent_returning(
+        monkeypatch,
+        {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+    )
+
+    # Manually create a draft owned by a *different* user. We poke the store
+    # directly because TestClient is anchored to the dev-mode user.
+    fake_result = {
+        "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+        "posts": {"x": {"draft": "r", "feedback": "f", "final": "f"}},
+    }
+    drafts = store.save_drafts("other-user", "p" * 20, fake_result)
+    other_id = drafts[0]["id"]
+
+    client = TestClient(main.app)  # auths as the dev-mode user, not "other-user"
+    res = client.get(f"/drafts/{other_id}/citations")
+    assert res.status_code == 404
+
+
+def test_variations_with_research_carries_citations(monkeypatch):
+    def fake_variations(self, product, platform, n=5, *, research_context=None):
+        return [{"angle": f"angle-{i}", "content": f"c-{i}"} for i in range(n)]
+
+    monkeypatch.setattr(main.SocialAgent, "variations", fake_variations)
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+
+    store.upsert_snippets(
+        uid, [Snippet(source="hn", url="https://e.com/v", title="v", score=0.5)]
+    )
+
+    res = client.post(
+        "/variations",
+        json={"product": "a sample product blurb", "platform": "x", "count": 3, "use_research": True},
+    )
+    assert res.status_code == 200
+    drafts = res.json()["drafts"]
+    assert len(drafts) == 3
+    assert all(len(d["cited_snippet_ids"]) == 1 for d in drafts)

--- a/docs/RESEARCH_LOOP.md
+++ b/docs/RESEARCH_LOOP.md
@@ -1,0 +1,206 @@
+# Research loop — operator's guide
+
+Fanout's research loop pulls live signals (HN, Dev.to, Reddit, RSS) and folds them into the agent's prompt so drafts can reference what's actually being discussed today, not just the static product blurb.
+
+This doc walks the loop end-to-end — what the pieces are, how to wire them, and how to verify each step is doing what you expect.
+
+## At a glance
+
+```
+   ┌────────────────────┐
+   │ /research/suggest  │ ← seed queries from a product blurb (cuts cold-start)
+   └──────────┬─────────┘
+              │
+   ┌──────────▼─────────┐    ┌──────────────────────┐
+   │ /research          │ ←─ │ subscriptions + cron │
+   │ (manual / per-tick)│    │ /research/tick[/all] │
+   └──────────┬─────────┘    └──────────────────────┘
+              │ persists, deduped per (user_id, url)
+              ▼
+   ┌────────────────────┐
+   │  research_snippets │ ← scored by popularity × recency
+   └──────────┬─────────┘
+              │ top N unused fed into prompt when use_research:true
+              ▼
+   ┌────────────────────┐
+   │ /generate          │ → drafts.cited_snippet_ids points back at sources
+   │ /variations        │   exposed via /drafts/{id}/citations
+   └────────────────────┘
+```
+
+## Data model
+
+| Table                       | What it holds                                                              |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `research_snippets`         | One row per unique `(user_id, url)`. Score, source, query, dedup primitive. |
+| `research_subscriptions`    | Saved query + interval configs. `last_run_at` drives the tick scheduler.   |
+| `drafts.cited_snippet_ids`  | JSON list of snippet ids that fed each draft's prompt (closes the loop).   |
+
+Migrations live under `backend/migrations/00{2,3,4}_*.sql` — apply in order on a fresh database, or rely on SQLAlchemy `create_all` in dev.
+
+## Endpoints
+
+### Seeding queries
+
+```bash
+# What should I track for this product?
+curl -s -X POST http://localhost:8000/research/suggest \
+  -H 'content-type: application/json' \
+  -d '{"product":"Fanout — agentic content studio for indie shippers","count":5}'
+# → {"queries":["agentic content tools","indie hacker marketing","ai social media","content automation","developer tools launch"]}
+```
+
+### One-off fetch
+
+```bash
+curl -s -X POST http://localhost:8000/research \
+  -H 'content-type: application/json' \
+  -d '{
+    "queries": ["agentic content tools", "indie hacker marketing"],
+    "rss_feeds": ["https://news.ycombinator.com/rss"]
+  }'
+```
+
+### Recurring subscriptions
+
+```bash
+# Save the config; the subscription runs autonomously
+curl -s -X POST http://localhost:8000/research/subscriptions \
+  -H 'content-type: application/json' \
+  -d '{
+    "name": "Indie launch tracker",
+    "queries": ["indie hackers", "show hn launch"],
+    "rss_feeds": ["https://www.indiehackers.com/feed.xml"],
+    "interval_hours": 6
+  }'
+
+# Trigger your own due subscriptions manually
+curl -s -X POST http://localhost:8000/research/tick
+
+# Cron-driven fan-out across all users (requires X-Tick-Secret)
+curl -s -X POST http://localhost:8000/research/tick/all \
+  -H "X-Tick-Secret: ${RESEARCH_TICK_SECRET}"
+```
+
+### Generating drafts that cite signals
+
+```bash
+# Variations on a single platform
+curl -s -X POST http://localhost:8000/variations \
+  -H 'content-type: application/json' \
+  -d '{
+    "product": "Fanout — agentic content studio for indie shippers",
+    "platform": "linkedin",
+    "use_research": true
+  }'
+# → {"drafts":[{"cited_snippet_ids":["...","..."], ...}], "research_used": 8}
+
+# See exactly which signals fed a draft
+curl -s http://localhost:8000/drafts/<draft_id>/citations
+# → {"draft_id":"...","snippets":[{"source":"hn","title":"...","url":"...","score":0.71}, ...]}
+```
+
+## Wiring the cron
+
+`/research/tick/all` is the multi-user endpoint. It's gated by an `X-Tick-Secret` header that matches `RESEARCH_TICK_SECRET` in the backend env — without that env var set, the endpoint returns 403. This avoids any auth surprise: no secret, no service-auth path.
+
+A minimum viable cron is one HTTP POST per minute. The endpoint is idempotent — subscriptions that aren't due yet are skipped — so over-polling is safe.
+
+### GitHub Action (free)
+
+```yaml
+# .github/workflows/research-tick.yml
+name: research-tick
+on:
+  schedule:
+    - cron: "*/5 * * * *"   # every 5 min; tick is idempotent so this is safe
+jobs:
+  tick:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -fsS -X POST "${{ secrets.FANOUT_API_URL }}/research/tick/all" \
+            -H "X-Tick-Secret: ${{ secrets.RESEARCH_TICK_SECRET }}"
+```
+
+### Vercel cron
+
+```json
+// vercel.json
+{
+  "crons": [
+    {
+      "path": "/api/research-tick",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}
+```
+
+…and have `/api/research-tick` proxy to the backend with the header.
+
+### Render scheduled job
+
+Set the command to:
+
+```bash
+curl -fsS -X POST "$FANOUT_API_URL/research/tick/all" -H "X-Tick-Secret: $RESEARCH_TICK_SECRET"
+```
+
+Schedule it on Render's cron tab.
+
+## Scoring model
+
+Each snippet's score is `(popularity × recency)^0.5` — a geometric mean so both factors must be reasonable to score well. Recency uses an exponential half-life of 48 hours (so 2-day-old content is worth half what brand-new content is). Per-source soft-max popularity:
+
+| Source  | soft-max | Notes                                                          |
+| ------- | -------- | -------------------------------------------------------------- |
+| HN      | 200      | Roughly a respectable HN front-page item.                      |
+| Reddit  | 500      | Communities run hotter than HN — calibrate higher.             |
+| Dev.to  | 120      | Reactions are scarcer than HN points.                          |
+| RSS     | n/a      | No popularity signal — recency-only, capped at 0.7 so an HN/Reddit hit can outrank a fresh RSS item. |
+
+Comments are weighted 1.5× points/upvotes — discussion is a stronger signal than a passive vote.
+
+## Verifying the loop
+
+```bash
+# 1. seed
+curl -s -X POST http://localhost:8000/research/suggest \
+  -d '{"product":"<your blurb>","count":5}' | jq '.queries'
+
+# 2. fetch (using the suggestions)
+curl -s -X POST http://localhost:8000/research \
+  -d '{"queries":[...],"rss_feeds":[]}' | jq '.fetched'
+
+# 3. confirm snippets exist + are unused
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+
+# 4. generate; check research_used > 0
+curl -s -X POST http://localhost:8000/variations \
+  -d '{"product":"<blurb>","platform":"linkedin","use_research":true}' | jq '.research_used'
+
+# 5. confirm citations on the produced draft
+curl -s 'http://localhost:8000/drafts/<id>/citations' | jq '.snippets | length'
+
+# 6. confirm those snippets are now marked used (won't re-surface to the next /generate)
+curl -s 'http://localhost:8000/research?only_unused=true' | jq 'length'
+```
+
+If step 6 returns the same count as step 3, the citation marking didn't run — check the backend logs for the `mark_snippets_used` call site and confirm `RESEARCH_TICK_SECRET` isn't accidentally muting the path.
+
+## Common gotchas
+
+- **Empty research after `/generate`.** The agent only consumes **unused** snippets. Run `/research` again or wait for the next subscription tick.
+- **`UnknownPricingError` is a different module.** That's `agentbudget`. Fanout's research loop has no per-source pricing.
+- **Reddit 429s under the cron.** Reddit rate-limits unauthed requests. The configured User-Agent (`fanout-research/0.1`) helps, but if you hit limits, lower your subscription `interval_hours` or shrink the query list.
+- **Citations look stale.** `cited_snippet_ids` is the source of truth on each draft. The `used_in_draft_id` field on snippets is a back-compat shortcut — if you need a definitive "what fed this draft?" answer, hit `/drafts/{id}/citations`.
+
+## Where the code lives
+
+- `backend/app/research.py` — source fetchers, scoring, parallel orchestration
+- `backend/app/store.py` — snippets + subscriptions CRUD, `top_snippets_for_agent`, `mark_snippets_used`, `get_draft_citations`
+- `backend/app/main.py` — REST handlers (`/research`, `/research/suggest`, `/research/subscriptions`, `/research/tick`, `/research/tick/all`)
+- `backend/app/agent.py` — `plan` / `write` / `variations` accept `research_context` and bake it into prompts
+- `web/app/research/page.tsx` — workbench UI (suggest, fetch, subscriptions list)
+- `web/components/CitationsPill.tsx` — the per-draft "N signals" pill

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -27,6 +27,7 @@ import Marquee from "@/components/Marquee";
 import Spotlight from "@/components/Spotlight";
 import AnimatedNumber from "@/components/AnimatedNumber";
 import Typewriter from "@/components/Typewriter";
+import { CitationsPill } from "@/components/CitationsPill";
 
 export default function Home() {
   const [product, setProduct] = useState("");
@@ -435,6 +436,12 @@ export default function Home() {
                             <span className="badge bg-white/5 text-white/60 ring-1 ring-white/10">
                               {d.feedback}
                             </span>
+                          )}
+                          {d.cited_snippet_ids && d.cited_snippet_ids.length > 0 && (
+                            <CitationsPill
+                              draftId={d.id}
+                              count={d.cited_snippet_ids.length}
+                            />
                           )}
                         </div>
                         <span className="text-[11px] tabular-nums text-white/40">

--- a/web/components/CitationsPill.tsx
+++ b/web/components/CitationsPill.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * Tiny pill that surfaces "this draft was grounded by N research signals."
+ * Lazy-fetches the snippet titles on first open to avoid an N+1 stampede when
+ * many cards mount at once — only drafts the user actually inspects pay the
+ * round-trip.
+ */
+
+import { useState } from "react";
+import { ExternalLink, Loader2, Newspaper } from "lucide-react";
+import { api, ResearchSnippet } from "@/lib/api";
+
+const SOURCE_LABEL: Record<string, string> = {
+  hn: "HN",
+  devto: "Dev.to",
+  reddit: "Reddit",
+  rss: "RSS",
+};
+
+export function CitationsPill({
+  draftId,
+  count,
+}: {
+  draftId: string;
+  count: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [snippets, setSnippets] = useState<ResearchSnippet[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  if (count <= 0) return null;
+
+  const toggle = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // don't trip the parent card's select-toggle
+    const next = !open;
+    setOpen(next);
+    if (next && !loaded && !loading) {
+      setLoading(true);
+      setError(null);
+      try {
+        const out = await api.citations(draftId);
+        setSnippets(out.snippets);
+        setLoaded(true);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        onClick={toggle}
+        className="inline-flex items-center gap-1 rounded-full border border-violet-400/30 bg-violet-500/10 px-2 py-0.5 text-[10px] font-medium text-violet-200 hover:bg-violet-500/20 transition-colors"
+        aria-expanded={open}
+        aria-label={`${count} research signal${count === 1 ? "" : "s"} grounded this draft`}
+      >
+        <Newspaper size={10} />
+        {count} signal{count === 1 ? "" : "s"}
+      </button>
+
+      {open && (
+        <div
+          className="absolute z-30 right-0 mt-1.5 w-72 rounded-xl border border-white/10 bg-black/95 p-3 shadow-2xl backdrop-blur-xl"
+          // Stop click propagation on the popover itself so users can interact
+          // with links / scrollbars without toggling the parent card.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="text-[10px] font-mono uppercase tracking-wider text-white/40 mb-2">
+            Grounded by
+          </div>
+          {loading ? (
+            <div className="text-xs text-white/50 flex items-center gap-1.5">
+              <Loader2 size={11} className="animate-spin" /> loading...
+            </div>
+          ) : error ? (
+            <div className="text-xs text-rose-300">{error}</div>
+          ) : snippets.length === 0 ? (
+            // The snippet may have been deleted from the bank since the draft
+            // was generated. Don't show a misleading "0" — explain what's up.
+            <div className="text-xs text-white/50">
+              Citations no longer in your bank.
+            </div>
+          ) : (
+            <ul className="space-y-1.5">
+              {snippets.map((s) => (
+                <li key={s.id} className="text-xs">
+                  <a
+                    href={s.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-start gap-1.5 text-white/85 hover:text-violet-200 leading-tight"
+                  >
+                    <span className="text-[9px] font-mono uppercase text-white/40 mt-0.5 shrink-0">
+                      {SOURCE_LABEL[s.source] ?? s.source}
+                    </span>
+                    <span className="line-clamp-2 flex-1">{s.title}</span>
+                    <ExternalLink size={9} className="opacity-50 mt-0.5 shrink-0" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -65,6 +65,10 @@ export const api = {
     }),
   cancelSchedule: (id: string) =>
     request<Draft>(`/drafts/${id}/schedule`, { method: "DELETE" }),
+  citations: (id: string) =>
+    request<{ draft_id: string; snippets: ResearchSnippet[] }>(
+      `/drafts/${id}/citations`
+    ),
   me: () => request<{ user_id: string }>("/me"),
 
   // --- research loop ---------------------------------------------------------
@@ -160,6 +164,9 @@ export type Draft = {
   scheduled_at: string | null;
   post_url?: string | null;
   error?: string | null;
+  // IDs of research snippets that fed this draft's prompt. Empty when the
+  // draft was generated without research grounding.
+  cited_snippet_ids?: string[];
   created_at: string;
 };
 


### PR DESCRIPTION
Stacks on **#33**. Merge order: #28 → #29 → #31 → #32 → #33 → this.

Closes the visibility loop on the research feature: every draft now records *which* research snippets fed its prompt, and the composer surfaces a **\"N signals\" pill** on each draft card that lazy-loads the snippet titles + links on click.

## Bug this fixes

\`/generate\` makes 15 drafts (one per platform) but the prior code stamped \`used_in_draft_id\` only against \`drafts[0]\`. The other 14 had **no audit trail.** Same for \`/variations\` — N drafts shared one attribution. Now every draft carries the full cited-id list.

## What ships

**Backend**
- \`Draft.cited_snippet_ids\` JSON column + migration 004
- \`store.save_drafts\` / \`save_variations\` accept \`cited_snippet_ids\` and write the same set onto every produced draft
- \`store.get_draft_citations\` returns snippets in their original save order (preserves the score-desc order they appeared in the agent prompt)
- \`GET /drafts/{id}/citations\` — owners-only, 404s match the standard auth boundary, returns \`{draft_id, snippets: [...]}\`

**Web**
- \`lib/api.ts\`: \`api.citations(id)\`; \`Draft\` type gains \`cited_snippet_ids\`
- \`components/CitationsPill.tsx\`: violet pill — lazy-fetches on first open (no N+1 stampede when many cards mount), event-isolated (\`stopPropagation\`) so clicking the pill doesn't toggle the parent card's select state
- Pill slots into the variation card header, alongside the existing angle badge

**Tests**
- 6 new pytest tests covering: per-draft attribution, no-research empty list, save-order preservation, 404 unknown draft, owners-only auth, variations path
- **53/53 backend tests passing**

## Back-compat note

The legacy \`used_in_draft_id\` field on snippets is preserved — the workbench's \"unused snippets\" filter still works. The new \`cited_snippet_ids\` JSON column on drafts is the canonical attribution going forward.

## Test plan

- [x] \`pytest tests/\` — 53/53 passing
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx next build\` clean — \`/research\` route unchanged size
- [ ] CI green
- [ ] Manual: bank a couple snippets, generate with \"Use live research\" on, click the violet \"N signals\" pill on a draft card, verify titles + links render and clicking them opens the source