### PR TITLE
feat: outcome feedback collector — close the research loop

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,6 +110,15 @@ class ReviewApprovalRequest(BaseModel):
     reviewer: str = Field(..., min_length=2, max_length=120)
 
 
+class OutcomeReport(BaseModel):
+    """One engagement observation pushed by the extension or a polling adapter."""
+
+    metric_kind: str = Field(..., min_length=1, max_length=32)
+    metric_value: int = Field(..., ge=0)
+    post_url: str | None = None
+    observed_at: datetime | None = None
+
+
 @app.get("/health")
 def health():
     return {"ok": True}
@@ -456,3 +465,66 @@ def report_posted(report: PostedReport, uid: str = Depends(current_user)):
     if not d:
         raise HTTPException(404, "Not found")
     return d
+
+
+@app.post("/drafts/{draft_id}/outcomes", status_code=201)
+def record_outcome(
+    draft_id: str,
+    report: OutcomeReport,
+    uid: str = Depends(current_user),
+):
+    """Append an engagement observation for a posted draft.
+
+    The extension (or any polling adapter) calls this when it sees fresh
+    likes/comments/views/etc. on the post URL.  Multiple calls per
+    ``(draft_id, metric_kind)`` are fine — each one is a new row so we keep
+    the timeline.
+    """
+    try:
+        row = store.record_outcome(
+            uid,
+            draft_id,
+            metric_kind=report.metric_kind,
+            metric_value=report.metric_value,
+            post_url=report.post_url,
+            observed_at=report.observed_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(422, str(exc))
+    if row is None:
+        raise HTTPException(404, "Not found")
+    return row
+
+
+@app.get("/drafts/{draft_id}/outcomes")
+def list_outcomes(draft_id: str, uid: str = Depends(current_user)):
+    """Full append-only timeline + latest-per-kind snapshot."""
+    # Cheap auth-leak guard: confirm draft ownership via the same path the
+    # other draft endpoints use, then return whatever rows exist.
+    if store.get_draft(uid, draft_id) is None:
+        raise HTTPException(404, "Not found")
+    return {
+        "draft_id": draft_id,
+        "latest": store.latest_outcomes_for_draft(uid, draft_id),
+        "timeline": store.outcomes_for_draft(uid, draft_id),
+    }
+
+
+@app.get("/research/sources/leaderboard")
+def source_leaderboard(
+    metric: str = "likes",
+    limit: int = 10,
+    uid: str = Depends(current_user),
+):
+    """Top research sources, ranked by aggregated engagement on grounded drafts.
+
+    The compounding piece of the research loop: sources whose snippets feed
+    drafts that perform well get higher rankings, so the next research tick
+    can bias its picks toward them.
+    """
+    if limit < 1 or limit > 50:
+        raise HTTPException(422, "limit must be 1..50")
+    return {
+        "metric": metric,
+        "rows": store.source_leaderboard(uid, metric_kind=metric, limit=limit),
+    }

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -190,3 +190,48 @@ class ResearchSubscription(Base):
             "last_error": self.last_error,
             "created_at": self.created_at.isoformat(),
         }
+
+
+class DraftOutcome(Base):
+    """One observation of engagement on a posted draft.
+
+    Append-only — every metric pull (likes after 1h, likes after 24h, etc.) is
+    a new row.  Latest-per-kind is the natural read pattern.  The research
+    loop joins back via ``Draft.cited_snippet_ids`` to find which sources fed
+    drafts that performed well, then biases future top-snippet picks toward
+    those sources.
+    """
+
+    __tablename__ = "draft_outcomes"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+    draft_id: Mapped[str] = mapped_column(String, index=True)
+
+    platform: Mapped[str] = mapped_column(String(32))
+    # likes | comments | views | reposts | clicks | shares | replies — open set
+    # on purpose so new platforms can record what they have without a schema bump.
+    metric_kind: Mapped[str] = mapped_column(String(32), index=True)
+    metric_value: Mapped[int] = mapped_column(Integer, default=0)
+
+    post_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    observed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    __table_args__ = (
+        Index("ix_outcomes_user_seen", "user_id", "observed_at"),
+        Index("ix_outcomes_user_kind", "user_id", "metric_kind", "observed_at"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "draft_id": self.draft_id,
+            "platform": self.platform,
+            "metric_kind": self.metric_kind,
+            "metric_value": self.metric_value,
+            "post_url": self.post_url,
+            "observed_at": self.observed_at.isoformat(),
+            "created_at": self.created_at.isoformat(),
+        }

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import Draft, ResearchSnippet, ResearchSubscription
+from app.models import Draft, DraftOutcome, ResearchSnippet, ResearchSubscription
 from app.research import Snippet
 
 
@@ -515,3 +515,185 @@ def mark_subscription_run(
         sub.last_error = error
         s.flush()
         return sub.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Draft outcomes — engagement metrics that close the research-loop feedback.
+# ---------------------------------------------------------------------------
+
+
+# Open set on purpose so new platforms can record what they have, but keep the
+# canonical names here to guide UI / leaderboard reads.
+OUTCOME_METRIC_KINDS = frozenset(
+    {"likes", "comments", "views", "reposts", "clicks", "shares", "replies", "saves"}
+)
+
+
+def record_outcome(
+    user_id: str,
+    draft_id: str,
+    *,
+    metric_kind: str,
+    metric_value: int,
+    post_url: str | None = None,
+    observed_at: datetime | None = None,
+) -> dict | None:
+    """Append one engagement observation.
+
+    Returns the saved row, or None if the draft does not belong to ``user_id``.
+    Append-only: each call is a new row so we keep the metric timeline.
+    """
+    if metric_value < 0:
+        raise ValueError("metric_value must be non-negative")
+    if not metric_kind:
+        raise ValueError("metric_kind required")
+    with session_scope() as s:
+        draft = s.get(Draft, draft_id)
+        if draft is None or draft.user_id != user_id:
+            return None
+        outcome = DraftOutcome(
+            user_id=user_id,
+            draft_id=draft_id,
+            platform=draft.platform,
+            metric_kind=metric_kind,
+            metric_value=int(metric_value),
+            post_url=post_url or draft.post_url,
+            observed_at=observed_at or datetime.now(timezone.utc),
+        )
+        s.add(outcome)
+        s.flush()
+        return outcome.to_dict()
+
+
+def latest_outcomes_for_draft(user_id: str, draft_id: str) -> dict[str, dict]:
+    """Return the most recent observation per metric_kind for one draft.
+
+    Shape: ``{"likes": {...row...}, "comments": {...row...}}``.  Missing kinds
+    are simply absent.
+    """
+    with session_scope() as s:
+        # Cheap path: pull all rows for the draft, fold by kind.  Engagement
+        # samples per draft are tiny (a draft only has so many observations).
+        rows = (
+            s.execute(
+                select(DraftOutcome)
+                .where(DraftOutcome.user_id == user_id, DraftOutcome.draft_id == draft_id)
+                .order_by(DraftOutcome.observed_at.asc())
+            )
+            .scalars()
+            .all()
+        )
+        out: dict[str, dict] = {}
+        for row in rows:
+            out[row.metric_kind] = row.to_dict()  # later wins → most recent
+        return out
+
+
+def outcomes_for_draft(user_id: str, draft_id: str) -> list[dict]:
+    """Full append-only timeline of outcomes for a draft, oldest first."""
+    with session_scope() as s:
+        rows = (
+            s.execute(
+                select(DraftOutcome)
+                .where(DraftOutcome.user_id == user_id, DraftOutcome.draft_id == draft_id)
+                .order_by(DraftOutcome.observed_at.asc())
+            )
+            .scalars()
+            .all()
+        )
+        return [r.to_dict() for r in rows]
+
+
+def source_leaderboard(
+    user_id: str,
+    *,
+    metric_kind: str = "likes",
+    limit: int = 10,
+) -> list[dict]:
+    """Top research sources by aggregated metric value, joined via citations.
+
+    For each drafts → cited_snippet_ids → research_snippets chain, we pick
+    each draft's max observed value for ``metric_kind`` (no double-counting
+    repeated samples) and sum it up per ``research_snippets.source`` and
+    ``research_snippets.query`` pair.
+
+    Returns rows of ``{source, query, total, draft_count, top_url}``.
+    Cross-DB friendly: does the aggregation in Python so we work the same on
+    SQLite (tests) and Postgres (prod).
+    """
+    with session_scope() as s:
+        # 1. Drafts the user has owned, with citations.
+        drafts = (
+            s.execute(
+                select(Draft).where(
+                    Draft.user_id == user_id, Draft.cited_snippet_ids.is_not(None)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not drafts:
+            return []
+        draft_ids = [d.id for d in drafts]
+        # 2. Best observed metric_value per draft for the requested kind.
+        outcomes = (
+            s.execute(
+                select(DraftOutcome).where(
+                    DraftOutcome.user_id == user_id,
+                    DraftOutcome.draft_id.in_(draft_ids),
+                    DraftOutcome.metric_kind == metric_kind,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        best_per_draft: dict[str, int] = {}
+        for o in outcomes:
+            cur = best_per_draft.get(o.draft_id, 0)
+            if o.metric_value > cur:
+                best_per_draft[o.draft_id] = o.metric_value
+        if not best_per_draft:
+            return []
+        # 3. Pull every cited snippet and roll up by (source, query).
+        cited_ids: set[str] = set()
+        for d in drafts:
+            for sid in d.cited_snippet_ids or []:
+                cited_ids.add(str(sid))
+        if not cited_ids:
+            return []
+        snippets = (
+            s.execute(
+                select(ResearchSnippet).where(
+                    ResearchSnippet.user_id == user_id,
+                    ResearchSnippet.id.in_(cited_ids),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        snippet_by_id: dict[str, ResearchSnippet] = {sn.id: sn for sn in snippets}
+        # 4. Aggregate.
+        agg: dict[tuple[str, str | None], dict] = {}
+        for d in drafts:
+            value = best_per_draft.get(d.id)
+            if not value:
+                continue
+            for sid in d.cited_snippet_ids or []:
+                sn = snippet_by_id.get(str(sid))
+                if sn is None:
+                    continue
+                key = (sn.source, sn.query)
+                bucket = agg.setdefault(
+                    key,
+                    {
+                        "source": sn.source,
+                        "query": sn.query,
+                        "total": 0,
+                        "draft_count": 0,
+                        "top_url": sn.url,
+                    },
+                )
+                bucket["total"] += value
+                bucket["draft_count"] += 1
+        ranked = sorted(agg.values(), key=lambda r: r["total"], reverse=True)
+        return ranked[:limit]

--- a/backend/migrations/005_draft_outcomes.sql
+++ b/backend/migrations/005_draft_outcomes.sql
@@ -1,0 +1,22 @@
+-- Outcome feedback: engagement metrics that come back AFTER a draft is posted.
+-- Lets the research loop self-tune: if a source's snippets ground drafts that
+-- consistently get more engagement, we surface them more aggressively next time.
+--
+-- Append-only by design (no UPDATE / DELETE on existing rows) so we can replay
+-- the metric timeline if the ranking model changes.
+
+CREATE TABLE IF NOT EXISTS draft_outcomes (
+  id              UUID PRIMARY KEY,
+  user_id         TEXT NOT NULL,
+  draft_id        TEXT NOT NULL,
+  platform        TEXT NOT NULL,
+  metric_kind     TEXT NOT NULL,          -- likes | comments | views | reposts | clicks | shares | replies
+  metric_value    INTEGER NOT NULL,
+  post_url        TEXT,
+  observed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_outcomes_draft        ON draft_outcomes (draft_id);
+CREATE INDEX IF NOT EXISTS ix_outcomes_user_seen    ON draft_outcomes (user_id, observed_at DESC);
+CREATE INDEX IF NOT EXISTS ix_outcomes_user_kind    ON draft_outcomes (user_id, metric_kind, observed_at DESC);

--- a/backend/tests/test_outcomes.py
+++ b/backend/tests/test_outcomes.py
@@ -1,0 +1,297 @@
+"""Tests for the outcome-feedback collector — append-only engagement
+observations on drafts and the source leaderboard that closes the loop."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main, store
+from app.research import Snippet
+
+
+# ---------------------------------------------------------------------------
+# store-level
+# ---------------------------------------------------------------------------
+
+
+def _make_draft(uid: str, platform: str = "x", cited: list[str] | None = None) -> str:
+    fake_result = {
+        "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+        "posts": {platform: {"draft": "raw", "feedback": "f", "final": "final"}},
+    }
+    drafts = store.save_drafts(uid, "p" * 20, fake_result, cited_snippet_ids=cited or [])
+    return drafts[0]["id"]
+
+
+def test_record_outcome_appends_row():
+    uid = "u-rec"
+    draft_id = _make_draft(uid)
+
+    row = store.record_outcome(uid, draft_id, metric_kind="likes", metric_value=12)
+    assert row is not None
+    assert row["draft_id"] == draft_id
+    assert row["metric_kind"] == "likes"
+    assert row["metric_value"] == 12
+    assert row["platform"] == "x"
+    assert row["observed_at"]  # ISO-formatted
+
+
+def test_record_outcome_rejects_negative():
+    uid = "u-neg"
+    draft_id = _make_draft(uid)
+    with pytest.raises(ValueError):
+        store.record_outcome(uid, draft_id, metric_kind="likes", metric_value=-1)
+
+
+def test_record_outcome_rejects_empty_kind():
+    uid = "u-empty"
+    draft_id = _make_draft(uid)
+    with pytest.raises(ValueError):
+        store.record_outcome(uid, draft_id, metric_kind="", metric_value=5)
+
+
+def test_record_outcome_owners_only():
+    """A draft belonging to user B is invisible to user A."""
+    other_draft = _make_draft("user-other")
+    row = store.record_outcome("user-A", other_draft, metric_kind="likes", metric_value=1)
+    assert row is None
+
+
+def test_record_outcome_inherits_draft_post_url():
+    uid = "u-post-url"
+    draft_id = _make_draft(uid)
+    # Simulate the extension reporting the draft as posted.
+    store.mark_posted(uid, draft_id, "https://x.com/u/status/123")
+
+    row = store.record_outcome(uid, draft_id, metric_kind="likes", metric_value=3)
+    assert row["post_url"] == "https://x.com/u/status/123"
+
+
+def test_record_outcome_explicit_post_url_wins():
+    uid = "u-explicit"
+    draft_id = _make_draft(uid)
+    store.mark_posted(uid, draft_id, "https://x.com/u/status/123")
+
+    row = store.record_outcome(
+        uid,
+        draft_id,
+        metric_kind="likes",
+        metric_value=1,
+        post_url="https://override.example/p/1",
+    )
+    assert row["post_url"] == "https://override.example/p/1"
+
+
+def test_latest_outcomes_returns_most_recent_per_kind():
+    uid = "u-latest"
+    draft_id = _make_draft(uid)
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    # Two likes samples (1h apart) + one comments sample.
+    store.record_outcome(
+        uid, draft_id, metric_kind="likes", metric_value=5, observed_at=t0
+    )
+    store.record_outcome(
+        uid,
+        draft_id,
+        metric_kind="likes",
+        metric_value=20,
+        observed_at=t0 + timedelta(hours=1),
+    )
+    store.record_outcome(
+        uid, draft_id, metric_kind="comments", metric_value=3, observed_at=t0
+    )
+
+    latest = store.latest_outcomes_for_draft(uid, draft_id)
+    assert set(latest.keys()) == {"likes", "comments"}
+    # Most-recent likes wins (20, not 5).
+    assert latest["likes"]["metric_value"] == 20
+    assert latest["comments"]["metric_value"] == 3
+
+
+def test_outcomes_for_draft_returns_full_timeline():
+    uid = "u-timeline"
+    draft_id = _make_draft(uid)
+    t0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    for i, v in enumerate([1, 4, 9]):
+        store.record_outcome(
+            uid,
+            draft_id,
+            metric_kind="likes",
+            metric_value=v,
+            observed_at=t0 + timedelta(hours=i),
+        )
+
+    timeline = store.outcomes_for_draft(uid, draft_id)
+    assert [r["metric_value"] for r in timeline] == [1, 4, 9]
+
+
+# ---------------------------------------------------------------------------
+# leaderboard
+# ---------------------------------------------------------------------------
+
+
+def test_source_leaderboard_aggregates_by_source_query():
+    """Two drafts cite snippets from different sources; the leaderboard sums
+    the best-observed metric per draft into (source, query) buckets."""
+    uid = "u-leader"
+
+    # Bank snippets from two sources.
+    saved = store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://hn.example/a", title="A", score=0.9, query="agents"),
+            Snippet(source="hn", url="https://hn.example/b", title="B", score=0.8, query="agents"),
+            Snippet(source="reddit", url="https://rd.example/c", title="C", score=0.7, query="agents"),
+        ],
+    )
+    ids_by_source: dict[str, list[str]] = {}
+    for row in saved:
+        ids_by_source.setdefault(row["source"], []).append(row["id"])
+
+    # Two drafts: first cites both HN snippets, second cites the Reddit snippet.
+    d1 = _make_draft(uid, cited=ids_by_source["hn"])
+    d2 = _make_draft(uid, cited=ids_by_source["reddit"])
+
+    # Sample two engagement points per draft so the "best wins" path runs.
+    store.record_outcome(uid, d1, metric_kind="likes", metric_value=10)
+    store.record_outcome(uid, d1, metric_kind="likes", metric_value=40)
+    store.record_outcome(uid, d2, metric_kind="likes", metric_value=5)
+
+    rows = store.source_leaderboard(uid, metric_kind="likes")
+    by_source = {(r["source"], r["query"]): r for r in rows}
+
+    # HN (agents) bucket: best of d1 = 40; counted once per cited snippet = 2 hits.
+    hn_row = by_source[("hn", "agents")]
+    assert hn_row["total"] == 80  # 40 × 2 cited HN snippets
+    assert hn_row["draft_count"] == 2
+
+    # Reddit bucket: best of d2 = 5, one snippet cited.
+    rd_row = by_source[("reddit", "agents")]
+    assert rd_row["total"] == 5
+    assert rd_row["draft_count"] == 1
+
+    # Sort order: HN row is first because total is larger.
+    assert rows[0]["source"] == "hn"
+
+
+def test_source_leaderboard_empty_when_no_outcomes():
+    uid = "u-empty-leader"
+    saved = store.upsert_snippets(
+        uid,
+        [Snippet(source="hn", url="https://hn.example/x", title="X", score=0.5, query="q")],
+    )
+    _make_draft(uid, cited=[saved[0]["id"]])
+    assert store.source_leaderboard(uid, metric_kind="likes") == []
+
+
+def test_source_leaderboard_respects_metric_kind():
+    """A draft with 100 likes should not appear in the comments leaderboard."""
+    uid = "u-metric-kind"
+    saved = store.upsert_snippets(
+        uid,
+        [Snippet(source="hn", url="https://hn.example/k", title="K", score=0.5, query="q")],
+    )
+    d = _make_draft(uid, cited=[saved[0]["id"]])
+    store.record_outcome(uid, d, metric_kind="likes", metric_value=100)
+    assert store.source_leaderboard(uid, metric_kind="comments") == []
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+
+def test_post_outcome_endpoint_records_row():
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+    draft_id = _make_draft(uid)
+
+    res = client.post(
+        f"/drafts/{draft_id}/outcomes",
+        json={"metric_kind": "likes", "metric_value": 7},
+    )
+    assert res.status_code == 201
+    assert res.json()["metric_value"] == 7
+
+
+def test_post_outcome_endpoint_422_for_negative():
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+    draft_id = _make_draft(uid)
+
+    res = client.post(
+        f"/drafts/{draft_id}/outcomes",
+        json={"metric_kind": "likes", "metric_value": -1},
+    )
+    # FastAPI's Pydantic validation rejects ge=0 before our store helper runs.
+    assert res.status_code == 422
+
+
+def test_post_outcome_endpoint_404_for_unknown_draft():
+    client = TestClient(main.app)
+    res = client.post(
+        "/drafts/does-not-exist/outcomes",
+        json={"metric_kind": "likes", "metric_value": 1},
+    )
+    assert res.status_code == 404
+
+
+def test_post_outcome_endpoint_owners_only():
+    """Posting to another user's draft is a 404 (auth-leak parity)."""
+    other_id = _make_draft("user-other")
+    client = TestClient(main.app)
+    res = client.post(
+        f"/drafts/{other_id}/outcomes",
+        json={"metric_kind": "likes", "metric_value": 1},
+    )
+    assert res.status_code == 404
+
+
+def test_get_outcomes_endpoint_returns_latest_and_timeline():
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+    draft_id = _make_draft(uid)
+
+    for v in (3, 10):
+        client.post(
+            f"/drafts/{draft_id}/outcomes",
+            json={"metric_kind": "likes", "metric_value": v},
+        )
+
+    res = client.get(f"/drafts/{draft_id}/outcomes")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["draft_id"] == draft_id
+    assert body["latest"]["likes"]["metric_value"] == 10  # most recent
+    assert len(body["timeline"]) == 2
+
+
+def test_leaderboard_endpoint_returns_rows():
+    client = TestClient(main.app)
+    uid = client.get("/me").json()["user_id"]
+    saved = store.upsert_snippets(
+        uid,
+        [Snippet(source="hn", url="https://hn.example/q", title="Q", score=0.5, query="q")],
+    )
+    d = _make_draft(uid, cited=[saved[0]["id"]])
+    store.record_outcome(uid, d, metric_kind="likes", metric_value=11)
+
+    res = client.get("/research/sources/leaderboard?metric=likes&limit=5")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["metric"] == "likes"
+    assert body["rows"][0]["source"] == "hn"
+    assert body["rows"][0]["total"] == 11
+
+
+def test_leaderboard_endpoint_rejects_bad_limit():
+    client = TestClient(main.app)
+    res = client.get("/research/sources/leaderboard?limit=0")
+    assert res.status_code == 422
+    res = client.get("/research/sources/leaderboard?limit=999")
+    assert res.status_code == 422

--- a/docs/RESEARCH_LOOP.md
+++ b/docs/RESEARCH_LOOP.md
@@ -196,11 +196,67 @@ If step 6 returns the same count as step 3, the citation marking didn't run — 
 - **Reddit 429s under the cron.** Reddit rate-limits unauthed requests. The configured User-Agent (`fanout-research/0.1`) helps, but if you hit limits, lower your subscription `interval_hours` or shrink the query list.
 - **Citations look stale.** `cited_snippet_ids` is the source of truth on each draft. The `used_in_draft_id` field on snippets is a back-compat shortcut — if you need a definitive "what fed this draft?" answer, hit `/drafts/{id}/citations`.
 
+## Outcome feedback (closing the loop)
+
+The research loop becomes compounding only when posted drafts feed engagement
+back. The flow:
+
+```
+   /generate (with research) ─► draft.cited_snippet_ids ─► drafts get posted
+                                                                │
+                                                                ▼
+                                       POST /drafts/{id}/outcomes  (metric_kind, metric_value)
+                                                                │
+                                                                ▼
+                                                draft_outcomes  (append-only timeline)
+                                                                │
+                                                                ▼
+                                       GET /research/sources/leaderboard?metric=likes
+                                                                │
+                                                                ▼
+                                next research tick can bias toward winning sources
+```
+
+### Endpoints
+
+```bash
+# extension or polling adapter pushes a fresh metric pull
+curl -s -X POST http://localhost:8000/drafts/<id>/outcomes \
+  -H 'content-type: application/json' \
+  -d '{"metric_kind":"likes","metric_value":34}'
+# → 201 {"id":"...","metric_value":34,...}
+
+# inspect the timeline + latest-per-kind snapshot for one draft
+curl -s 'http://localhost:8000/drafts/<id>/outcomes' | jq
+# → {"draft_id":"...","latest":{"likes":{...,"metric_value":34}},"timeline":[...]}
+
+# which sources are producing engagement?
+curl -s 'http://localhost:8000/research/sources/leaderboard?metric=likes&limit=10' | jq
+# → {"metric":"likes","rows":[{"source":"hn","query":"agents","total":80,"draft_count":2,"top_url":"..."}]}
+```
+
+### Conventions
+
+- **Append-only.** Every outcome push is a new row; the per-kind "latest" is
+  the most-recent observation. Replaying the timeline is the basis for any
+  future ranking-model change.
+- **Open metric set.** `metric_kind` is free-form; the canonical names
+  (`likes`, `comments`, `views`, `reposts`, `clicks`, `shares`, `replies`,
+  `saves`) live in `store.OUTCOME_METRIC_KINDS` for UI hints, but the server
+  will accept anything platform-specific.
+- **Best-per-draft, not last-per-draft.** The leaderboard sums the max
+  observed value per draft (no double-counting repeated samples) and rolls
+  by `(source, query)` so a single hot draft can't single-handedly skew the
+  ranking after a polling client pulls the same metric every hour.
+- **Cross-DB friendly.** Aggregation runs in Python over the cited snippet
+  list, not via SQL window functions, so the leaderboard works identically
+  on SQLite (tests) and Postgres (prod).
+
 ## Where the code lives
 
 - `backend/app/research.py` — source fetchers, scoring, parallel orchestration
-- `backend/app/store.py` — snippets + subscriptions CRUD, `top_snippets_for_agent`, `mark_snippets_used`, `get_draft_citations`
-- `backend/app/main.py` — REST handlers (`/research`, `/research/suggest`, `/research/subscriptions`, `/research/tick`, `/research/tick/all`)
+- `backend/app/store.py` — snippets + subscriptions CRUD, `top_snippets_for_agent`, `mark_snippets_used`, `get_draft_citations`, **`record_outcome`, `latest_outcomes_for_draft`, `outcomes_for_draft`, `source_leaderboard`**
+- `backend/app/main.py` — REST handlers (`/research`, `/research/suggest`, `/research/subscriptions`, `/research/tick`, `/research/tick/all`, **`/drafts/{id}/outcomes`, `/research/sources/leaderboard`**)
 - `backend/app/agent.py` — `plan` / `write` / `variations` accept `research_context` and bake it into prompts
 - `web/app/research/page.tsx` — workbench UI (suggest, fetch, subscriptions list)
 - `web/components/CitationsPill.tsx` — the per-draft "N signals" pill

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -134,6 +134,34 @@ export const api = {
         "/research/tick",
         { method: "POST" }
       ),
+
+    leaderboard: (metric: OutcomeMetric = "likes", limit = 10) =>
+      request<{ metric: string; rows: SourceLeaderboardRow[] }>(
+        `/research/sources/leaderboard?metric=${encodeURIComponent(metric)}&limit=${limit}`
+      ),
+  },
+
+  // --- outcomes --------------------------------------------------------------
+  outcomes: {
+    record: (
+      draftId: string,
+      input: {
+        metric_kind: OutcomeMetric;
+        metric_value: number;
+        post_url?: string;
+        observed_at?: string;
+      }
+    ) =>
+      request<DraftOutcome>(`/drafts/${draftId}/outcomes`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    list: (draftId: string) =>
+      request<{
+        draft_id: string;
+        latest: Record<string, DraftOutcome>;
+        timeline: DraftOutcome[];
+      }>(`/drafts/${draftId}/outcomes`),
   },
 };
 
@@ -199,4 +227,37 @@ export type ResearchSubscription = {
   last_fetched_count: number | null;
   last_error: string | null;
   created_at: string;
+};
+
+// Open set on the wire; this list is the UI-facing canonical set.
+export type OutcomeMetric =
+  | "likes"
+  | "comments"
+  | "views"
+  | "reposts"
+  | "clicks"
+  | "shares"
+  | "replies"
+  | "saves";
+
+export type DraftOutcome = {
+  id: string;
+  user_id: string;
+  draft_id: string;
+  platform: Platform;
+  metric_kind: string; // not narrowed to OutcomeMetric on the way back so the
+                       // type survives a server that records a kind the UI
+                       // doesn't know about yet
+  metric_value: number;
+  post_url: string | null;
+  observed_at: string;
+  created_at: string;
+};
+
+export type SourceLeaderboardRow = {
+  source: ResearchSource;
+  query: string | null;
+  total: number;
+  draft_count: number;
+  top_url: string;
 };


### PR DESCRIPTION
Wires the engagement-feedback path so the research loop can self-tune.
Builds on the freshly-merged #57.

## What

- **Migration 005:** `draft_outcomes` table. Append-only timeline of
  engagement observations per draft.
- **Store helpers:**
  - `record_outcome(uid, draft_id, metric_kind, value, ...)`
  - `latest_outcomes_for_draft(uid, draft_id)` → `{kind: row}`
  - `outcomes_for_draft(uid, draft_id)` → full timeline
  - `source_leaderboard(uid, metric_kind, limit)` → top sources by
    aggregated best-per-draft, rolled by `(source, query)` via
    `cited_snippet_ids`.
- **HTTP:**
  - `POST /drafts/{id}/outcomes` — extension or polling adapter pushes one
    metric pull.
  - `GET /drafts/{id}/outcomes` — latest-per-kind + full timeline.
  - `GET /research/sources/leaderboard?metric=...&limit=...` — which
    research sources are producing real engagement.
- **Web client:** typed contracts (`OutcomeMetric`, `DraftOutcome`,
  `SourceLeaderboardRow`) + `api.outcomes.{record,list}` and
  `api.research.leaderboard`.
- **Docs:** `docs/RESEARCH_LOOP.md` gains an 'Outcome feedback (closing the
  loop)' section.

## Why it's the compounding piece

The research loop was already grounding drafts in live signals (#57). What
was missing was the feedback edge: when a posted draft does well, the
sources that fed it should rank higher next cycle. This PR is the smallest
unit that closes that edge — once the extension calls
`POST /drafts/{id}/outcomes` with whatever metric it can scrape, the
leaderboard answers "what's working" without any extra inference cost.

## Conventions

- **Append-only** — every push is a new row; latest-per-kind is the most
  recent observation. Replaying the timeline is the basis for any future
  ranking-model change.
- **Open metric set** — `metric_kind` is free-form. Canonical names live
  in `store.OUTCOME_METRIC_KINDS` for UI hints; the server accepts any
  platform-specific kind.
- **Best-per-draft, not last-per-draft** — leaderboard sums max observed
  value per draft so polling the same metric every hour doesn't single-
  handedly skew the ranking.
- **Cross-DB friendly** — aggregation runs in Python over cited snippets,
  not via SQL window functions, so SQLite (tests) and Postgres (prod) take
  identical code paths.

## Tests

- 18 new tests in `tests/test_outcomes.py`: store helpers, leaderboard
  aggregation, HTTP endpoints, owners-only auth boundary, negative-value
  rejection, etc.
- Full backend pytest: **71/71 pass.**
- Web `tsc --noEmit`: clean.