### PR TITLE
feat: Eva operator — autonomous draft cycle with leaderboard-weighted picks

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from pydantic import BaseModel, Field  # noqa: E402
 
-from app import store  # noqa: E402
+from app import operator, store  # noqa: E402
 from app.agent import PLATFORMS, SocialAgent  # noqa: E402
 from app.auth import current_user  # noqa: E402
 from app.db import init_db  # noqa: E402
@@ -117,6 +117,21 @@ class OutcomeReport(BaseModel):
     metric_value: int = Field(..., ge=0)
     post_url: str | None = None
     observed_at: datetime | None = None
+
+
+class OperatorRunRequest(BaseModel):
+    """Parameters for one Eva operator cycle.
+
+    ``weight_by_leaderboard`` defaults true so the operator self-tunes once
+    outcomes start flowing in; cold-start safely falls back to score-only
+    picking with no leaderboard signal.
+    """
+
+    product: str = Field(..., min_length=10, max_length=8000)
+    platforms: list[str] = Field(default_factory=lambda: list(PLATFORMS))
+    weight_by_leaderboard: bool = True
+    leaderboard_metric: str = Field(default="likes", min_length=1, max_length=32)
+    snippet_limit: int = Field(default=8, ge=1, le=20)
 
 
 @app.get("/health")
@@ -528,3 +543,53 @@ def source_leaderboard(
         "metric": metric,
         "rows": store.source_leaderboard(uid, metric_kind=metric, limit=limit),
     }
+
+
+# ---------------------------------------------------------------------------
+# Eva operator — autonomous draft cycle.
+# ---------------------------------------------------------------------------
+
+
+@app.post("/operator/run")
+def operator_run(req: OperatorRunRequest, uid: str = Depends(current_user)):
+    """Run one autonomous Eva cycle: pick → draft → log.
+
+    Returns the OperatorRun id, the agent plan, the drafts produced, the
+    snippets the operator picked, and whether leaderboard weighting actually
+    influenced the picks (false during cold-start).
+    """
+    try:
+        result = operator.run(
+            uid,
+            product=req.product,
+            platforms=req.platforms,
+            weight_by_leaderboard=req.weight_by_leaderboard,
+            leaderboard_metric=req.leaderboard_metric,
+            snippet_limit=req.snippet_limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    return {
+        "operator_run_id": result.run_id,
+        "plan": result.plan,
+        "drafts": result.drafts,
+        "picked_snippets": result.picked_snippets,
+        "leaderboard_used": result.leaderboard_used,
+        "winning_sources": result.winning_sources,
+    }
+
+
+@app.get("/operator/runs")
+def operator_runs_list(limit: int = 20, uid: str = Depends(current_user)):
+    """Audit trail: most-recent operator cycles first."""
+    if limit < 1 or limit > 100:
+        raise HTTPException(422, "limit must be 1..100")
+    return store.list_operator_runs(uid, limit=limit)
+
+
+@app.get("/operator/runs/{run_id}")
+def operator_run_get(run_id: str, uid: str = Depends(current_user)):
+    row = store.get_operator_run(uid, run_id)
+    if row is None:
+        raise HTTPException(404, "Not found")
+    return row

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -235,3 +235,55 @@ class DraftOutcome(Base):
             "observed_at": self.observed_at.isoformat(),
             "created_at": self.created_at.isoformat(),
         }
+
+
+class OperatorRun(Base):
+    """One autonomous cycle of the Eva operator.
+
+    Picks an experiment (a subset of research snippets), drafts platform-
+    tailored posts, and records the snippets + drafts it produced. Becomes
+    the audit trail for "what did the operator try on 2026-05-24?" and the
+    basis for comparing weighting strategies against each other later.
+    """
+
+    __tablename__ = "operator_runs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+
+    product: Mapped[str] = mapped_column(Text)
+    platforms: Mapped[list] = mapped_column(JSON, default=list)
+    cited_snippet_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    draft_ids: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
+    weight_by_leaderboard: Mapped[bool] = mapped_column(Boolean, default=True)
+    leaderboard_metric: Mapped[str] = mapped_column(String(32), default="likes")
+
+    status: Mapped[str] = mapped_column(String(16), default="pending", index=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    __table_args__ = (
+        Index("ix_operator_runs_user_started", "user_id", "started_at"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "product": self.product,
+            "platforms": list(self.platforms or []),
+            "cited_snippet_ids": list(self.cited_snippet_ids or []),
+            "draft_ids": list(self.draft_ids or []),
+            "weight_by_leaderboard": self.weight_by_leaderboard,
+            "leaderboard_metric": self.leaderboard_metric,
+            "status": self.status,
+            "error": self.error,
+            "notes": self.notes,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+        }

--- a/backend/app/operator.py
+++ b/backend/app/operator.py
@@ -1,0 +1,130 @@
+"""Eva operator — one autonomous draft-generation cycle.
+
+The operator is a thin wrapper around the existing /generate pipeline that
+adds two things:
+
+1.  An **autonomous experiment picker** that biases snippet selection toward
+    sources whose past drafts have produced engagement (via the outcome
+    leaderboard).  Cold-start falls back to plain score-desc.
+2.  An **OperatorRun audit row** for every cycle so we can replay what was
+    picked and how it performed later.
+
+Kept separate from ``main.py`` so the endpoint stays narrow and the operator
+logic is testable in isolation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app import store
+from app.agent import PLATFORMS, SocialAgent
+from app.research import Snippet, format_for_prompt
+
+
+@dataclass
+class OperatorResult:
+    run_id: str
+    plan: dict
+    drafts: list[dict]
+    picked_snippets: list[dict]
+    leaderboard_used: bool
+    winning_sources: list[dict]
+
+
+def run(
+    user_id: str,
+    *,
+    product: str,
+    platforms: list[str] | None = None,
+    weight_by_leaderboard: bool = True,
+    leaderboard_metric: str = "likes",
+    snippet_limit: int = 8,
+    agent: SocialAgent | None = None,
+) -> OperatorResult:
+    """Drive one operator cycle end-to-end.
+
+    The ``agent`` parameter is the seam tests use to inject a stubbed agent
+    so we never hit Groq.  Production paths leave it unset and build a real
+    SocialAgent on demand.
+
+    Raises whatever the agent raises if the underlying call fails, but
+    always closes out the OperatorRun row (``failed`` on exception, ``ok``
+    on success) so the audit trail never leaks ``pending`` rows.
+    """
+    platforms = platforms or list(PLATFORMS)
+    invalid = [p for p in platforms if p not in PLATFORMS]
+    if invalid:
+        raise ValueError(f"Invalid platforms: {invalid}")
+
+    run_row = store.start_operator_run(
+        user_id,
+        product=product,
+        platforms=platforms,
+        weight_by_leaderboard=weight_by_leaderboard,
+        leaderboard_metric=leaderboard_metric,
+    )
+    run_id = run_row["id"]
+
+    try:
+        pick = store.select_experiment_snippets(
+            user_id,
+            limit=snippet_limit,
+            weight_by_leaderboard=weight_by_leaderboard,
+            leaderboard_metric=leaderboard_metric,
+        )
+        snippets = pick["snippets"]
+        snippet_ids = [s["id"] for s in snippets]
+        research_block = None
+        if snippets:
+            objs = [
+                Snippet(
+                    source=s["source"],
+                    url=s["url"],
+                    title=s["title"],
+                    snippet=s.get("snippet"),
+                    score=s.get("score") or 0.0,
+                )
+                for s in snippets
+            ]
+            research_block = format_for_prompt(objs)
+
+        agent = agent or SocialAgent()
+        result = agent.run(product, platforms=tuple(platforms), research_context=research_block)
+        drafts = store.save_drafts(user_id, product, result, cited_snippet_ids=snippet_ids)
+        if snippet_ids and drafts:
+            store.mark_snippets_used(user_id, snippet_ids, drafts[0]["id"])
+
+        notes = _build_notes(pick, drafts_count=len(drafts))
+        store.complete_operator_run(
+            user_id,
+            run_id,
+            cited_snippet_ids=snippet_ids,
+            draft_ids=[d["id"] for d in drafts],
+            notes=notes,
+        )
+        return OperatorResult(
+            run_id=run_id,
+            plan=result.get("plan", {}),
+            drafts=drafts,
+            picked_snippets=snippets,
+            leaderboard_used=pick["leaderboard_used"],
+            winning_sources=pick["winning_sources"],
+        )
+    except Exception as exc:  # noqa: BLE001 — capture, log, re-raise
+        store.fail_operator_run(user_id, run_id, error=f"{type(exc).__name__}: {exc}")
+        raise
+
+
+def _build_notes(pick: dict, *, drafts_count: int) -> str:
+    if pick["leaderboard_used"]:
+        winners = ", ".join(
+            f"{w['source']}/{w['query'] or '*'}" for w in pick["winning_sources"][:5]
+        )
+        return (
+            f"leaderboard-weighted; {len(pick['snippets'])} snippets fed "
+            f"{drafts_count} drafts. winners: {winners}"
+        )
+    if not pick["snippets"]:
+        return f"cold-start (no banked snippets); {drafts_count} drafts produced ungrounded"
+    return f"cold-start (no leaderboard yet); {len(pick['snippets'])} top-score snippets fed {drafts_count} drafts"

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import Draft, DraftOutcome, ResearchSnippet, ResearchSubscription
+from app.models import Draft, DraftOutcome, OperatorRun, ResearchSnippet, ResearchSubscription
 from app.research import Snippet
 
 
@@ -697,3 +697,150 @@ def source_leaderboard(
                 bucket["draft_count"] += 1
         ranked = sorted(agg.values(), key=lambda r: r["total"], reverse=True)
         return ranked[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Eva operator — autonomous experiment picker + draft generator audit trail.
+# ---------------------------------------------------------------------------
+
+
+def select_experiment_snippets(
+    user_id: str,
+    *,
+    limit: int = 8,
+    weight_by_leaderboard: bool = True,
+    leaderboard_metric: str = "likes",
+) -> dict:
+    """Pick the snippets for one autonomous operator cycle.
+
+    Returns:
+        {
+            "snippets": [...up to ``limit`` rows...],
+            "leaderboard_used": bool,        # True only when boosting actually changed picks
+            "winning_sources": [(source, query), ...],
+        }
+
+    Cold-start safe: with no leaderboard signal, falls back to
+    ``top_snippets_for_agent`` (score desc among unused).
+    """
+    candidates = list_snippets(user_id, only_unused=True, limit=limit * 3)
+    if not candidates:
+        return {"snippets": [], "leaderboard_used": False, "winning_sources": []}
+
+    if not weight_by_leaderboard:
+        return {
+            "snippets": candidates[:limit],
+            "leaderboard_used": False,
+            "winning_sources": [],
+        }
+
+    board = source_leaderboard(user_id, metric_kind=leaderboard_metric, limit=20)
+    winners: dict[tuple[str, str | None], int] = {}
+    for row in board:
+        winners[(row["source"], row["query"])] = row["total"]
+    if not winners:
+        # Cold-start: keep the score-only ordering, just trim.
+        return {
+            "snippets": candidates[:limit],
+            "leaderboard_used": False,
+            "winning_sources": [],
+        }
+
+    # Score = raw_score + leaderboard_boost.  We want leaderboard signal to
+    # be the dominant factor once it exists, so the top winner contributes
+    # boost = 1.0 — strong enough to outrank a non-winner snippet at raw
+    # score 0.95.  Non-winning sources contribute nothing.  Raw score still
+    # breaks ties within the same (source, query) bucket so freshness +
+    # popularity continue to matter.
+    max_total = max(winners.values())
+
+    def boosted_score(snip: dict) -> float:
+        boost = winners.get((snip["source"], snip.get("query")), 0)
+        normalized = boost / max_total if max_total else 0.0
+        return (snip.get("score") or 0.0) + normalized
+
+    reordered = sorted(candidates, key=boosted_score, reverse=True)[:limit]
+    return {
+        "snippets": reordered,
+        "leaderboard_used": True,
+        "winning_sources": [{"source": s, "query": q} for (s, q) in winners.keys()],
+    }
+
+
+def start_operator_run(
+    user_id: str,
+    *,
+    product: str,
+    platforms: list[str],
+    weight_by_leaderboard: bool,
+    leaderboard_metric: str,
+) -> dict:
+    """Insert an OperatorRun row in ``pending`` status. Returns the dict view."""
+    with session_scope() as s:
+        row = OperatorRun(
+            user_id=user_id,
+            product=product,
+            platforms=list(platforms),
+            weight_by_leaderboard=bool(weight_by_leaderboard),
+            leaderboard_metric=leaderboard_metric,
+            status="pending",
+        )
+        s.add(row)
+        s.flush()
+        return row.to_dict()
+
+
+def complete_operator_run(
+    user_id: str,
+    run_id: str,
+    *,
+    cited_snippet_ids: list[str],
+    draft_ids: list[str],
+    notes: str | None = None,
+) -> dict | None:
+    with session_scope() as s:
+        row = s.get(OperatorRun, run_id)
+        if row is None or row.user_id != user_id:
+            return None
+        row.cited_snippet_ids = list(cited_snippet_ids)
+        row.draft_ids = list(draft_ids)
+        row.notes = notes
+        row.status = "ok"
+        row.completed_at = datetime.now(timezone.utc)
+        s.flush()
+        return row.to_dict()
+
+
+def fail_operator_run(user_id: str, run_id: str, *, error: str) -> dict | None:
+    with session_scope() as s:
+        row = s.get(OperatorRun, run_id)
+        if row is None or row.user_id != user_id:
+            return None
+        row.status = "failed"
+        row.error = error
+        row.completed_at = datetime.now(timezone.utc)
+        s.flush()
+        return row.to_dict()
+
+
+def list_operator_runs(user_id: str, *, limit: int = 20) -> list[dict]:
+    with session_scope() as s:
+        rows = (
+            s.execute(
+                select(OperatorRun)
+                .where(OperatorRun.user_id == user_id)
+                .order_by(OperatorRun.started_at.desc())
+                .limit(limit)
+            )
+            .scalars()
+            .all()
+        )
+        return [r.to_dict() for r in rows]
+
+
+def get_operator_run(user_id: str, run_id: str) -> dict | None:
+    with session_scope() as s:
+        row = s.get(OperatorRun, run_id)
+        if row is None or row.user_id != user_id:
+            return None
+        return row.to_dict()

--- a/backend/migrations/006_operator_runs.sql
+++ b/backend/migrations/006_operator_runs.sql
@@ -1,0 +1,26 @@
+-- Eva operator: each autonomous draft-generation cycle gets one log row.
+-- Lets us replay "what did the operator pick on 2026-05-24?" and rank model
+-- versions / weighting strategies against each other later.
+
+CREATE TABLE IF NOT EXISTS operator_runs (
+  id                       UUID PRIMARY KEY,
+  user_id                  TEXT NOT NULL,
+
+  product                  TEXT NOT NULL,
+  platforms                JSONB NOT NULL,           -- list of platform ids
+  cited_snippet_ids        JSONB,                    -- snippets fed to the agent
+  draft_ids                JSONB,                    -- drafts produced
+  weight_by_leaderboard    BOOLEAN NOT NULL DEFAULT TRUE,
+  leaderboard_metric       TEXT NOT NULL DEFAULT 'likes',
+
+  status                   TEXT NOT NULL DEFAULT 'pending',  -- pending|ok|failed
+  error                    TEXT,
+  notes                    TEXT,
+
+  started_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at             TIMESTAMPTZ,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_operator_runs_user_started ON operator_runs (user_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS ix_operator_runs_user_status  ON operator_runs (user_id, status);

--- a/backend/tests/test_operator.py
+++ b/backend/tests/test_operator.py
@@ -1,0 +1,251 @@
+"""Tests for the Eva operator — autonomous experiment picker + audit row.
+
+Covers:
+  * select_experiment_snippets cold-start (no outcomes yet) → falls back to
+    score-only ordering.
+  * select_experiment_snippets warm path → reorders by leaderboard winners.
+  * operator.run end-to-end with a stubbed agent: logs OperatorRun, saves
+    drafts with citations, marks snippets used, no real Groq call.
+  * operator.run failure path: OperatorRun ends up in ``failed`` status with
+    the exception captured (no ``pending`` rows leak).
+  * /operator/run, /operator/runs, /operator/runs/{id} endpoints.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app import main, operator, store
+from app.research import Snippet
+
+
+def _stub_agent(monkeypatch, *, plan_dict=None, raise_exc: Exception | None = None):
+    """Patch SocialAgent.run so the operator does not touch Groq."""
+
+    plan_dict = plan_dict or {
+        "audience": "a",
+        "angle": "b",
+        "key_points": ["c"],
+        "tone": "d",
+        "cta": "e",
+    }
+
+    def fake_run(self, product, platforms, *, research_context=None):
+        if raise_exc is not None:
+            raise raise_exc
+        return {
+            "plan": plan_dict,
+            "posts": {
+                p: {"draft": "raw", "feedback": "ok", "final": f"final-{p}"}
+                for p in platforms
+            },
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", fake_run)
+
+
+# ---------------------------------------------------------------------------
+# picker
+# ---------------------------------------------------------------------------
+
+
+def test_select_experiment_cold_start_returns_top_score():
+    uid = "u-cold"
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/a", title="A", score=0.9, query="q"),
+            Snippet(source="hn", url="https://e.com/b", title="B", score=0.5, query="q"),
+        ],
+    )
+    pick = store.select_experiment_snippets(uid, limit=2)
+    assert [s["title"] for s in pick["snippets"]] == ["A", "B"]
+    assert pick["leaderboard_used"] is False
+    assert pick["winning_sources"] == []
+
+
+def test_select_experiment_cold_start_empty_when_no_snippets():
+    pick = store.select_experiment_snippets("u-none", limit=5)
+    assert pick == {"snippets": [], "leaderboard_used": False, "winning_sources": []}
+
+
+def test_select_experiment_reorders_by_leaderboard():
+    """A lower-score snippet from a winning source should outrank a higher-
+    score snippet from a source that has never produced engagement."""
+    uid = "u-warm"
+
+    # Step 1 — populate engagement history: an OLD HN/agents snippet was cited
+    # by a draft that earned 50 likes.  This makes HN/agents a leaderboard
+    # winner.  The old snippet then ages out of the unused pool naturally
+    # (used_in_draft_id is set), so the picker won't see it again.
+    old = store.upsert_snippets(
+        uid,
+        [Snippet(source="hn", url="https://hn.example/old", title="HN-old", score=0.9, query="agents")],
+    )
+    fake_result = {
+        "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+        "posts": {"x": {"draft": "r", "feedback": "f", "final": "f"}},
+    }
+    drafts = store.save_drafts(uid, "p" * 20, fake_result, cited_snippet_ids=[old[0]["id"]])
+    store.mark_snippets_used(uid, [old[0]["id"]], drafts[0]["id"])
+    store.record_outcome(uid, drafts[0]["id"], metric_kind="likes", metric_value=50)
+
+    # Step 2 — fresh fetch brings in a NEW HN snippet (mid-score) and a NEW
+    # Reddit snippet (high-score).  The picker only sees unused rows.
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://hn.example/new", title="HN-new", score=0.4, query="agents"),
+            Snippet(source="reddit", url="https://rd.example/new", title="RD-new", score=0.95, query="agents"),
+        ],
+    )
+
+    pick = store.select_experiment_snippets(uid, limit=5, weight_by_leaderboard=True)
+    sources = [s["source"] for s in pick["snippets"]]
+    # Boost should pull HN ahead of Reddit despite Reddit's higher raw score.
+    assert sources.index("hn") < sources.index("reddit")
+    assert pick["leaderboard_used"] is True
+
+
+def test_select_experiment_respects_weight_flag():
+    uid = "u-noweight"
+    store.upsert_snippets(
+        uid,
+        [
+            Snippet(source="hn", url="https://e.com/a", title="A", score=0.9, query="q"),
+        ],
+    )
+    pick = store.select_experiment_snippets(uid, weight_by_leaderboard=False)
+    assert pick["leaderboard_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# operator.run
+# ---------------------------------------------------------------------------
+
+
+def test_operator_run_logs_audit_row_and_saves_drafts(monkeypatch):
+    _stub_agent(monkeypatch)
+    uid = "u-run"
+    store.upsert_snippets(
+        uid,
+        [Snippet(source="hn", url="https://e.com/a", title="A", score=0.9, query="q")],
+    )
+
+    res = operator.run(
+        uid,
+        product="a sample product blurb",
+        platforms=["x"],
+    )
+    assert res.run_id
+    assert len(res.drafts) == 1
+    assert len(res.picked_snippets) == 1
+    # Audit row exists, is ok, and points at the same draft.
+    run_row = store.get_operator_run(uid, res.run_id)
+    assert run_row["status"] == "ok"
+    assert run_row["draft_ids"] == [res.drafts[0]["id"]]
+    assert run_row["cited_snippet_ids"] == [res.picked_snippets[0]["id"]]
+    assert "cold-start" in (run_row["notes"] or "")
+
+
+def test_operator_run_ungrounded_when_no_snippets(monkeypatch):
+    _stub_agent(monkeypatch)
+    uid = "u-empty"
+    res = operator.run(uid, product="a sample product blurb", platforms=["x"])
+    assert res.picked_snippets == []
+    assert res.leaderboard_used is False
+    run_row = store.get_operator_run(uid, res.run_id)
+    assert run_row["status"] == "ok"
+    assert run_row["cited_snippet_ids"] == []
+    assert "ungrounded" in (run_row["notes"] or "")
+
+
+def test_operator_run_failure_marks_run_failed(monkeypatch):
+    _stub_agent(monkeypatch, raise_exc=RuntimeError("boom"))
+    uid = "u-fail"
+
+    try:
+        operator.run(uid, product="a sample product blurb", platforms=["x"])
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("operator.run should re-raise")
+
+    runs = store.list_operator_runs(uid)
+    assert len(runs) == 1
+    assert runs[0]["status"] == "failed"
+    assert "RuntimeError" in (runs[0]["error"] or "")
+    assert runs[0]["completed_at"]  # closed out, not left pending
+
+
+def test_operator_run_rejects_invalid_platform(monkeypatch):
+    _stub_agent(monkeypatch)
+    try:
+        operator.run("u-bad-plat", product="a sample product blurb", platforms=["nope"])
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for unknown platform")
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+
+def test_post_operator_run_endpoint(monkeypatch):
+    _stub_agent(monkeypatch)
+    client = TestClient(main.app)
+
+    res = client.post(
+        "/operator/run",
+        json={"product": "a sample product blurb", "platforms": ["x", "linkedin"]},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["operator_run_id"]
+    assert len(body["drafts"]) == 2
+    assert "winning_sources" in body
+    assert body["leaderboard_used"] is False  # cold-start
+
+
+def test_post_operator_run_endpoint_rejects_invalid_platform(monkeypatch):
+    _stub_agent(monkeypatch)
+    client = TestClient(main.app)
+    res = client.post(
+        "/operator/run",
+        json={"product": "a sample product blurb", "platforms": ["nope"]},
+    )
+    assert res.status_code == 400
+
+
+def test_list_operator_runs_endpoint(monkeypatch):
+    _stub_agent(monkeypatch)
+    client = TestClient(main.app)
+    for _ in range(3):
+        client.post("/operator/run", json={"product": "a sample product blurb", "platforms": ["x"]})
+
+    res = client.get("/operator/runs?limit=5")
+    assert res.status_code == 200
+    rows = res.json()
+    assert len(rows) == 3
+    assert all(r["status"] == "ok" for r in rows)
+
+
+def test_get_operator_run_404(monkeypatch):
+    client = TestClient(main.app)
+    res = client.get("/operator/runs/does-not-exist")
+    assert res.status_code == 404
+
+
+def test_operator_runs_owners_only(monkeypatch):
+    _stub_agent(monkeypatch)
+    other_run = store.start_operator_run(
+        "user-other",
+        product="x" * 20,
+        platforms=["x"],
+        weight_by_leaderboard=False,
+        leaderboard_metric="likes",
+    )
+    client = TestClient(main.app)
+    res = client.get(f"/operator/runs/{other_run['id']}")
+    assert res.status_code == 404

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,0 +1,100 @@
+# Eva operator — autonomous draft cycle
+
+The operator is the thinnest possible layer that wraps `/generate` with
+two extras:
+
+1. **An experiment picker** that biases snippet selection toward sources
+   whose past drafts have produced engagement.  Cold-start safe — falls
+   back to plain score-desc when no leaderboard signal exists.
+2. **An audit row** (`operator_runs`) for every cycle so we can replay
+   what was picked and how it performed later.
+
+Think of it as the "press a button, get a fully grounded slate of
+platform drafts" surface.  Everything it does is also available via the
+manual `/generate` path; the operator just chains them together with the
+weighting and the log.
+
+## The cycle
+
+```
+   /operator/run
+        │
+        ▼
+   select_experiment_snippets(uid, limit, weight_by_leaderboard)
+        │   ├─ unused snippets, score-desc
+        │   └─ +leaderboard boost (source, query) → total of top winner
+        ▼
+   format_for_prompt(snippets) ─► SocialAgent.run(product, platforms, research)
+        │
+        ▼
+   save_drafts(uid, product, result, cited_snippet_ids=...)
+        │
+        ▼
+   mark_snippets_used(...)
+        │
+        ▼
+   complete_operator_run(run_id, cited_snippet_ids, draft_ids, notes)
+```
+
+If anything raises, the run row lands in `failed` status with the
+exception class + message captured — no row ever stays `pending`.
+
+## Endpoints
+
+```bash
+# one autonomous cycle, all platforms, leaderboard-weighted
+curl -s -X POST http://localhost:8000/operator/run \
+  -H 'content-type: application/json' \
+  -d '{"product":"Fanout — agentic content studio for indie shippers","platforms":["x","linkedin"]}'
+# → {"operator_run_id":"...","plan":{...},"drafts":[...],
+#    "picked_snippets":[...],"leaderboard_used":false,"winning_sources":[]}
+
+# audit trail (newest first)
+curl -s 'http://localhost:8000/operator/runs?limit=20' | jq
+
+# one specific run
+curl -s 'http://localhost:8000/operator/runs/<run_id>' | jq
+```
+
+## Weighting
+
+- `weight_by_leaderboard` (default `true`).  When false, the picker uses
+  the same ordering as the manual workbench — `top_snippets_for_agent`
+  → unused, sorted by `score`.
+- `leaderboard_metric` (default `"likes"`) — pick a different metric
+  (e.g. `"comments"` or `"shares"`) to bias against engagement quality
+  instead of raw reach.
+- Cold-start: with no `draft_outcomes` rows yet, the picker silently
+  falls back to score-only.  `leaderboard_used` in the response is
+  `false` so the caller can tell which mode ran.
+
+## The notes field
+
+Every completed run carries a one-line `notes` string suitable for
+showing in a UI:
+
+- `"leaderboard-weighted; 5 snippets fed 4 drafts. winners: hn/agents, reddit/agents, ..."`
+- `"cold-start (no leaderboard yet); 5 top-score snippets fed 4 drafts"`
+- `"cold-start (no banked snippets); 4 drafts produced ungrounded"`
+
+## Pairing with cron
+
+There is no built-in operator scheduler yet — drive `/operator/run` from
+the same hourly cron that already runs `/research/tick/all` if you want
+the loop to be fully autonomous.  Recommended sequence:
+
+1. `/research/tick/all`   — pull fresh signals
+2. `/operator/run`        — pick + draft
+3. extension polls `/queue` → posts → reports outcomes
+
+## Where the code lives
+
+- `backend/app/operator.py` — `operator.run(uid, ...)` end-to-end driver
+- `backend/app/store.py` — `select_experiment_snippets`,
+  `start_operator_run`, `complete_operator_run`, `fail_operator_run`,
+  `list_operator_runs`, `get_operator_run`
+- `backend/app/models.py` — `OperatorRun` SQLAlchemy model
+- `backend/migrations/006_operator_runs.sql`
+- `backend/app/main.py` — `/operator/run`, `/operator/runs`,
+  `/operator/runs/{run_id}`
+- `web/lib/api.ts` — `api.operator.{run,list,get}` typed client

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -163,6 +163,30 @@ export const api = {
         timeline: DraftOutcome[];
       }>(`/drafts/${draftId}/outcomes`),
   },
+
+  // --- operator (Eva) --------------------------------------------------------
+  operator: {
+    run: (input: {
+      product: string;
+      platforms?: Platform[];
+      weight_by_leaderboard?: boolean;
+      leaderboard_metric?: OutcomeMetric;
+      snippet_limit?: number;
+    }) =>
+      request<{
+        operator_run_id: string;
+        plan: Record<string, unknown>;
+        drafts: Draft[];
+        picked_snippets: ResearchSnippet[];
+        leaderboard_used: boolean;
+        winning_sources: { source: ResearchSource; query: string | null }[];
+      }>("/operator/run", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    list: (limit = 20) => request<OperatorRun[]>(`/operator/runs?limit=${limit}`),
+    get: (runId: string) => request<OperatorRun>(`/operator/runs/${runId}`),
+  },
 };
 
 export type Status = "pending" | "queued" | "scheduled" | "posting" | "posted" | "failed";
@@ -260,4 +284,22 @@ export type SourceLeaderboardRow = {
   total: number;
   draft_count: number;
   top_url: string;
+};
+
+export type OperatorRunStatus = "pending" | "ok" | "failed";
+
+export type OperatorRun = {
+  id: string;
+  user_id: string;
+  product: string;
+  platforms: Platform[];
+  cited_snippet_ids: string[];
+  draft_ids: string[];
+  weight_by_leaderboard: boolean;
+  leaderboard_metric: string;
+  status: OperatorRunStatus;
+  error: string | null;
+  notes: string | null;
+  started_at: string;
+  completed_at: string | null;
 };


### PR DESCRIPTION
Closes the loop opened by #57 and #58: pull research, draft from it,
collect engagement, then **let the operator pick what to draft next** —
biased toward sources that have actually produced engagement.

## What

- **`select_experiment_snippets(uid, ...)`** — picks unused snippets,
  boosts those whose `(source, query)` pair shows up in the engagement
  leaderboard. Boost magnitude = the source's normalized leaderboard
  total; max boost = 1.0 so a top winner can flip a non-winner with
  raw score up to 0.95. Cold-start safe: falls back to score-desc when
  no outcomes exist.
- **`OperatorRun` audit row** — every cycle logs product, platforms,
  picked snippet ids, produced draft ids, status, and a one-line note
  suitable for UI. Never leaves `pending`; exceptions land it in
  `failed` with the error captured.
- **Endpoints:**
  - `POST /operator/run` — one cycle. Returns drafts + picks + whether
    leaderboard weighting actually influenced anything.
  - `GET /operator/runs` — audit trail, newest first.
  - `GET /operator/runs/{id}` — one run by id.
- **`app/operator.py`** — separate module so the operator driver is
  testable without going through HTTP and the endpoint stays narrow.
- **Typed web client:** `api.operator.{run, list, get}` and `OperatorRun`
  type, ready for a future operator-history UI.
- **`docs/OPERATOR.md`** — cycle diagram, weighting modes, notes-field
  vocabulary, cron pairing recipe.

## Why this is the actual compounding piece

The research loop (#57) brought live signals in. The outcome collector
(#58) recorded which posts worked. This PR is the wiring that **uses
those outcomes to pick the next experiment**, without a human in the
loop. Press one button, get a slate of drafts grounded in the sources
that have historically produced engagement.

The cron pairing is intentional: run `/research/tick/all` then
`/operator/run` on the same hourly cron and the loop self-tunes.

## Tests

- 13 new in `tests/test_operator.py` — picker cold-start, leaderboard
  reorder, run logs audit row, failure path captures exception, HTTP
  contract, owners-only auth.
- Backend pytest: **84/84 pass.**
- Web `tsc --noEmit`: clean.