### PR TITLE
feat: operator scheduler — subscriptions + tick + hourly cron

### DIFF
--- a/.github/workflows/operator-tick.yml
+++ b/.github/workflows/operator-tick.yml
@@ -1,0 +1,111 @@
+# Operator-tick cron — drives the autonomous Eva operator on a cadence.
+# Mirrors research-tick.yml: hits POST /operator/tick/all so every active
+# operator subscription across every user fires when it is due.
+#
+# Disabled by default. To enable:
+#   1. Deploy the backend with env var OPERATOR_TICK_SECRET set to a strong
+#      random string (the service auth token for the fan-out endpoint).
+#   2. Set repo VARIABLE  OPERATOR_TICK_ENABLED = "true"
+#   3. Set repo SECRET    OPERATOR_TICK_URL     = "https://api.example.com/operator/tick/all"
+#   4. Set repo SECRET    OPERATOR_TICK_SECRET  = "<same value as backend env>"
+#
+# Failures log a warning and exit 0 — a flaky backend should not redden the
+# repo's CI badge. The response summary lands in GITHUB_STEP_SUMMARY so the
+# Actions tab shows what ran without clicking in.
+
+name: Operator tick
+
+on:
+  schedule:
+    # Hourly. The tick endpoint is idempotent (subs that aren't due yet get
+    # skipped server-side), so cheap to run more often than the tightest
+    # subscription interval.
+    - cron: "37 * * * *"
+  workflow_dispatch:
+    # Manual fire from the Actions tab — handy for smoke-testing after
+    # changing subscription configs.
+
+permissions:
+  contents: read
+
+concurrency:
+  group: operator-tick
+  cancel-in-progress: false
+
+jobs:
+  tick:
+    if: vars.OPERATOR_TICK_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Probe required secrets
+        id: probe
+        env:
+          URL: ${{ secrets.OPERATOR_TICK_URL }}
+        run: |
+          if [ -z "$URL" ]; then
+            echo "::warning::OPERATOR_TICK_ENABLED is true but OPERATOR_TICK_URL is unset; nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Hit /operator/tick/all
+        if: steps.probe.outputs.skip != 'true'
+        env:
+          URL: ${{ secrets.OPERATOR_TICK_URL }}
+          TICK_SECRET: ${{ secrets.OPERATOR_TICK_SECRET }}
+        run: |
+          set -u
+          if [ -z "$TICK_SECRET" ]; then
+            echo "::warning::OPERATOR_TICK_SECRET is unset — backend will reject the request with 403."
+          fi
+          STATUS=$(curl -sS -X POST "$URL" \
+            -H 'content-type: application/json' \
+            -H "X-Tick-Secret: $TICK_SECRET" \
+            --max-time 300 \
+            -o response.json \
+            -w '%{http_code}' || echo "000")
+          echo "HTTP $STATUS"
+          echo "--- response ---"
+          cat response.json || true
+          echo
+          if [ "$STATUS" -lt 200 ] || [ "$STATUS" -ge 300 ]; then
+            echo "::warning::Operator tick returned HTTP $STATUS — check backend health and secret."
+          fi
+
+      - name: Summarize
+        if: steps.probe.outputs.skip != 'true' && always()
+        run: |
+          if [ -f response.json ]; then
+            python3 - <<'PY'
+          import json, os, pathlib
+          try:
+              data = json.loads(pathlib.Path("response.json").read_text())
+          except Exception as e:
+              print(f"could not parse response: {e}")
+              raise SystemExit(0)
+          ran = data.get("ran", []) if isinstance(data, dict) else []
+          total_drafts = sum(r.get("drafts", 0) or 0 for r in ran)
+          errors = [r for r in ran if r.get("error")]
+          summary = f"Ran {len(ran)} operator subscriptions, produced {total_drafts} drafts"
+          if errors:
+              summary += f", {len(errors)} with errors"
+          print(summary)
+          step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if step_summary:
+              with open(step_summary, "a") as f:
+                  f.write(f"### Operator tick\n\n{summary}\n")
+                  for r in ran:
+                      mark = "❌" if r.get("error") else "✅"
+                      f.write(
+                          f"- {mark} `{r.get('name','?')}` — "
+                          f"{r.get('drafts',0)} drafts"
+                      )
+                      if r.get("leaderboard_used"):
+                          f.write(" (leaderboard-weighted)")
+                      if r.get("error"):
+                          f.write(f" — error: `{r['error']}`")
+                      f.write("\n")
+          PY
+          fi

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -134,6 +134,28 @@ class OperatorRunRequest(BaseModel):
     snippet_limit: int = Field(default=8, ge=1, le=20)
 
 
+class OperatorSubscriptionCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128)
+    product: str = Field(..., min_length=10, max_length=8000)
+    platforms: list[str] = Field(default_factory=lambda: list(PLATFORMS))
+    weight_by_leaderboard: bool = True
+    leaderboard_metric: str = Field(default="likes", min_length=1, max_length=32)
+    snippet_limit: int = Field(default=8, ge=1, le=20)
+    interval_hours: int = Field(default=24, ge=1, le=24 * 7)
+    active: bool = True
+
+
+class OperatorSubscriptionUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+    product: str | None = Field(default=None, min_length=10, max_length=8000)
+    platforms: list[str] | None = None
+    weight_by_leaderboard: bool | None = None
+    leaderboard_metric: str | None = Field(default=None, min_length=1, max_length=32)
+    snippet_limit: int | None = Field(default=None, ge=1, le=20)
+    interval_hours: int | None = Field(default=None, ge=1, le=24 * 7)
+    active: bool | None = None
+
+
 @app.get("/health")
 def health():
     return {"ok": True}
@@ -593,3 +615,98 @@ def operator_run_get(run_id: str, uid: str = Depends(current_user)):
     if row is None:
         raise HTTPException(404, "Not found")
     return row
+
+
+# --- Operator subscriptions (stored configs that fire on a cadence) -----
+
+
+def _validate_platforms(platforms: list[str]) -> None:
+    invalid = [p for p in platforms if p not in PLATFORMS]
+    if invalid:
+        raise HTTPException(400, f"Invalid platforms: {invalid}. Valid: {PLATFORMS}")
+
+
+@app.post("/operator/subscriptions", status_code=201)
+def operator_subscription_create(
+    req: OperatorSubscriptionCreateRequest,
+    uid: str = Depends(current_user),
+):
+    _validate_platforms(req.platforms)
+    try:
+        return store.create_operator_subscription(
+            uid,
+            name=req.name,
+            product=req.product,
+            platforms=req.platforms,
+            weight_by_leaderboard=req.weight_by_leaderboard,
+            leaderboard_metric=req.leaderboard_metric,
+            snippet_limit=req.snippet_limit,
+            interval_hours=req.interval_hours,
+            active=req.active,
+        )
+    except ValueError as exc:
+        raise HTTPException(422, str(exc))
+
+
+@app.get("/operator/subscriptions")
+def operator_subscriptions_list(uid: str = Depends(current_user)):
+    return store.list_operator_subscriptions(uid)
+
+
+@app.patch("/operator/subscriptions/{sub_id}")
+def operator_subscription_update(
+    sub_id: str,
+    req: OperatorSubscriptionUpdateRequest,
+    uid: str = Depends(current_user),
+):
+    if req.platforms is not None:
+        _validate_platforms(req.platforms)
+    try:
+        row = store.update_operator_subscription(
+            uid,
+            sub_id,
+            name=req.name,
+            product=req.product,
+            platforms=req.platforms,
+            weight_by_leaderboard=req.weight_by_leaderboard,
+            leaderboard_metric=req.leaderboard_metric,
+            snippet_limit=req.snippet_limit,
+            interval_hours=req.interval_hours,
+            active=req.active,
+        )
+    except ValueError as exc:
+        raise HTTPException(422, str(exc))
+    if row is None:
+        raise HTTPException(404, "Not found")
+    return row
+
+
+@app.delete("/operator/subscriptions/{sub_id}")
+def operator_subscription_delete(sub_id: str, uid: str = Depends(current_user)):
+    if not store.delete_operator_subscription(uid, sub_id):
+        raise HTTPException(404, "Not found")
+    return {"deleted": sub_id}
+
+
+@app.post("/operator/tick")
+def operator_tick(uid: str = Depends(current_user)):
+    """Run every due operator subscription belonging to the authed user."""
+    return {"ran": operator.tick_user(uid)}
+
+
+@app.post("/operator/tick/all")
+def operator_tick_all(x_tick_secret: str | None = Header(default=None)):
+    """Service-auth tick — fire every due operator subscription across all users.
+
+    Auths via ``X-Tick-Secret`` (header), gated on ``OPERATOR_TICK_SECRET``.
+    Off by default: returns 403 unless ``OPERATOR_TICK_SECRET`` is set on
+    the backend.
+    """
+    expected = os.environ.get("OPERATOR_TICK_SECRET")
+    if not expected:
+        raise HTTPException(
+            403, "Service tick disabled — set OPERATOR_TICK_SECRET on the backend to enable."
+        )
+    if not x_tick_secret or not secrets.compare_digest(x_tick_secret, expected):
+        raise HTTPException(403, "Invalid X-Tick-Secret header")
+    return {"ran": operator.tick_all()}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -287,3 +287,59 @@ class OperatorRun(Base):
             "started_at": self.started_at.isoformat(),
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
         }
+
+
+class OperatorSubscription(Base):
+    """A stored operator config that fires on a cadence.
+
+    Tied to the `/operator/tick` endpoint (manual, per-user) and the
+    `/operator/tick/all` service-auth fan-out endpoint that the hourly
+    GitHub Action drives. ``last_run_at`` gates the cron so subs only fire
+    when ``now - last_run_at >= interval_hours``.
+    """
+
+    __tablename__ = "operator_subscriptions"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String, index=True)
+
+    name: Mapped[str] = mapped_column(String(128))
+    product: Mapped[str] = mapped_column(Text)
+    platforms: Mapped[list] = mapped_column(JSON, default=list)
+    weight_by_leaderboard: Mapped[bool] = mapped_column(Boolean, default=True)
+    leaderboard_metric: Mapped[str] = mapped_column(String(32), default="likes")
+    snippet_limit: Mapped[int] = mapped_column(Integer, default=8)
+
+    interval_hours: Mapped[int] = mapped_column(Integer, default=24)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    last_run_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+    __table_args__ = (
+        Index("ix_opsubs_active_lastrun", "active", "last_run_at"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "name": self.name,
+            "product": self.product,
+            "platforms": list(self.platforms or []),
+            "weight_by_leaderboard": self.weight_by_leaderboard,
+            "leaderboard_metric": self.leaderboard_metric,
+            "snippet_limit": self.snippet_limit,
+            "interval_hours": self.interval_hours,
+            "active": self.active,
+            "last_run_at": self.last_run_at.isoformat() if self.last_run_at else None,
+            "last_run_id": self.last_run_id,
+            "last_error": self.last_error,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/backend/app/operator.py
+++ b/backend/app/operator.py
@@ -128,3 +128,74 @@ def _build_notes(pick: dict, *, drafts_count: int) -> str:
     if not pick["snippets"]:
         return f"cold-start (no banked snippets); {drafts_count} drafts produced ungrounded"
     return f"cold-start (no leaderboard yet); {len(pick['snippets'])} top-score snippets fed {drafts_count} drafts"
+
+
+def tick_user(user_id: str, *, agent: SocialAgent | None = None) -> list[dict]:
+    """Fire every due operator subscription for one user.
+
+    Each subscription gets one ``operator.run`` cycle.  Failures are caught
+    per-subscription and logged into ``last_error`` — one bad sub does not
+    take down the rest.  Returns a list of result dicts shaped like:
+        {"subscription_id": ..., "name": ..., "run_id": ..., "drafts": N,
+         "error": null | str}
+    """
+    due = store.due_operator_subscriptions(user_id=user_id)
+    return _run_due(due, agent=agent)
+
+
+def tick_all(*, agent: SocialAgent | None = None) -> list[dict]:
+    """Fire every due operator subscription across every user.
+
+    Used by the service-auth ``/operator/tick/all`` endpoint and the hourly
+    GitHub Action.  Same per-subscription error isolation as ``tick_user``.
+    """
+    due = store.due_operator_subscriptions()
+    return _run_due(due, agent=agent)
+
+
+def _run_due(due: list[dict], *, agent: SocialAgent | None) -> list[dict]:
+    out: list[dict] = []
+    for sub in due:
+        sub_id = sub["id"]
+        try:
+            result = run(
+                sub["user_id"],
+                product=sub["product"],
+                platforms=sub["platforms"] or list(PLATFORMS),
+                weight_by_leaderboard=sub["weight_by_leaderboard"],
+                leaderboard_metric=sub["leaderboard_metric"],
+                snippet_limit=sub["snippet_limit"],
+                agent=agent,
+            )
+            store.mark_operator_subscription_run(
+                sub_id,
+                run_id=result.run_id,
+                error=None,
+            )
+            out.append(
+                {
+                    "subscription_id": sub_id,
+                    "name": sub["name"],
+                    "run_id": result.run_id,
+                    "drafts": len(result.drafts),
+                    "leaderboard_used": result.leaderboard_used,
+                    "error": None,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 — one bad sub shouldn't fail the batch
+            store.mark_operator_subscription_run(
+                sub_id,
+                run_id=None,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            out.append(
+                {
+                    "subscription_id": sub_id,
+                    "name": sub["name"],
+                    "run_id": None,
+                    "drafts": 0,
+                    "leaderboard_used": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+    return out

--- a/backend/app/store.py
+++ b/backend/app/store.py
@@ -7,7 +7,14 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.models import Draft, DraftOutcome, OperatorRun, ResearchSnippet, ResearchSubscription
+from app.models import (
+    Draft,
+    DraftOutcome,
+    OperatorRun,
+    OperatorSubscription,
+    ResearchSnippet,
+    ResearchSubscription,
+)
 from app.research import Snippet
 
 
@@ -843,4 +850,161 @@ def get_operator_run(user_id: str, run_id: str) -> dict | None:
         row = s.get(OperatorRun, run_id)
         if row is None or row.user_id != user_id:
             return None
+        return row.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Operator subscriptions — stored configs that fire on a cadence.
+# ---------------------------------------------------------------------------
+
+
+# Server-side bounds: keep cron-driven subs from drifting into pathologies.
+_OPSUB_INTERVAL_MIN_HOURS = 1
+_OPSUB_INTERVAL_MAX_HOURS = 24 * 7
+_OPSUB_SNIPPET_LIMIT_MAX = 20
+
+
+def _clamp_opsub(field: str, value, lo, hi):
+    if value is None:
+        return None
+    if value < lo or value > hi:
+        raise ValueError(f"{field} must be in [{lo}, {hi}]")
+    return value
+
+
+def create_operator_subscription(
+    user_id: str,
+    *,
+    name: str,
+    product: str,
+    platforms: list[str],
+    weight_by_leaderboard: bool = True,
+    leaderboard_metric: str = "likes",
+    snippet_limit: int = 8,
+    interval_hours: int = 24,
+    active: bool = True,
+) -> dict:
+    _clamp_opsub("interval_hours", interval_hours, _OPSUB_INTERVAL_MIN_HOURS, _OPSUB_INTERVAL_MAX_HOURS)
+    _clamp_opsub("snippet_limit", snippet_limit, 1, _OPSUB_SNIPPET_LIMIT_MAX)
+    with session_scope() as s:
+        row = OperatorSubscription(
+            user_id=user_id,
+            name=name,
+            product=product,
+            platforms=list(platforms),
+            weight_by_leaderboard=bool(weight_by_leaderboard),
+            leaderboard_metric=leaderboard_metric,
+            snippet_limit=int(snippet_limit),
+            interval_hours=int(interval_hours),
+            active=bool(active),
+        )
+        s.add(row)
+        s.flush()
+        return row.to_dict()
+
+
+def list_operator_subscriptions(user_id: str) -> list[dict]:
+    with session_scope() as s:
+        rows = s.scalars(
+            select(OperatorSubscription)
+            .where(OperatorSubscription.user_id == user_id)
+            .order_by(OperatorSubscription.created_at.desc())
+        ).all()
+        return [r.to_dict() for r in rows]
+
+
+def update_operator_subscription(
+    user_id: str,
+    sub_id: str,
+    *,
+    name: str | None = None,
+    product: str | None = None,
+    platforms: list[str] | None = None,
+    weight_by_leaderboard: bool | None = None,
+    leaderboard_metric: str | None = None,
+    snippet_limit: int | None = None,
+    interval_hours: int | None = None,
+    active: bool | None = None,
+) -> dict | None:
+    _clamp_opsub("interval_hours", interval_hours, _OPSUB_INTERVAL_MIN_HOURS, _OPSUB_INTERVAL_MAX_HOURS)
+    _clamp_opsub("snippet_limit", snippet_limit, 1, _OPSUB_SNIPPET_LIMIT_MAX)
+    with session_scope() as s:
+        row = s.get(OperatorSubscription, sub_id)
+        if row is None or row.user_id != user_id:
+            return None
+        if name is not None:
+            row.name = name
+        if product is not None:
+            row.product = product
+        if platforms is not None:
+            row.platforms = list(platforms)
+        if weight_by_leaderboard is not None:
+            row.weight_by_leaderboard = bool(weight_by_leaderboard)
+        if leaderboard_metric is not None:
+            row.leaderboard_metric = leaderboard_metric
+        if snippet_limit is not None:
+            row.snippet_limit = int(snippet_limit)
+        if interval_hours is not None:
+            row.interval_hours = int(interval_hours)
+        if active is not None:
+            row.active = bool(active)
+        s.flush()
+        return row.to_dict()
+
+
+def delete_operator_subscription(user_id: str, sub_id: str) -> bool:
+    with session_scope() as s:
+        row = s.get(OperatorSubscription, sub_id)
+        if row is None or row.user_id != user_id:
+            return False
+        s.delete(row)
+        return True
+
+
+def due_operator_subscriptions(
+    *,
+    user_id: str | None = None,
+    now: datetime | None = None,
+) -> list[dict]:
+    """Return active subscriptions whose ``last_run_at`` is older than
+    ``interval_hours``.  Cross-DB friendly: we do the recency check in
+    Python so SQLite (tests) and Postgres (prod) follow the same code path.
+    """
+    now = now or datetime.now(timezone.utc)
+    with session_scope() as s:
+        stmt = select(OperatorSubscription).where(OperatorSubscription.active.is_(True))
+        if user_id:
+            stmt = stmt.where(OperatorSubscription.user_id == user_id)
+        rows = s.scalars(stmt).all()
+        out: list[dict] = []
+        for row in rows:
+            if row.last_run_at is None:
+                out.append(row.to_dict())
+                continue
+            last = (
+                row.last_run_at.replace(tzinfo=timezone.utc)
+                if row.last_run_at.tzinfo is None
+                else row.last_run_at
+            )
+            if now - last >= timedelta(hours=row.interval_hours):
+                out.append(row.to_dict())
+        return out
+
+
+def mark_operator_subscription_run(
+    sub_id: str,
+    *,
+    run_id: str | None,
+    error: str | None = None,
+    when: datetime | None = None,
+) -> dict | None:
+    when = when or datetime.now(timezone.utc)
+    with session_scope() as s:
+        row = s.get(OperatorSubscription, sub_id)
+        if row is None:
+            return None
+        row.last_run_at = when
+        row.last_run_id = run_id
+        row.last_error = error
+        s.flush()
         return row.to_dict()

--- a/backend/migrations/007_operator_subscriptions.sql
+++ b/backend/migrations/007_operator_subscriptions.sql
@@ -1,0 +1,29 @@
+-- Operator subscriptions: stored configs that drive autonomous draft cycles.
+-- Paired with the /operator/tick endpoint and the hourly GitHub Action so a
+-- user can wire one product blurb + a platform list once and the operator
+-- will produce drafts on a cadence.
+
+CREATE TABLE IF NOT EXISTS operator_subscriptions (
+  id                       UUID PRIMARY KEY,
+  user_id                  TEXT NOT NULL,
+
+  name                     TEXT NOT NULL,
+  product                  TEXT NOT NULL,                         -- the blurb fed into /generate
+  platforms                JSONB NOT NULL DEFAULT '[]'::jsonb,
+  weight_by_leaderboard    BOOLEAN NOT NULL DEFAULT TRUE,
+  leaderboard_metric       TEXT NOT NULL DEFAULT 'likes',
+  snippet_limit            INTEGER NOT NULL DEFAULT 8,
+
+  interval_hours           INTEGER NOT NULL DEFAULT 24,           -- bounded server-side
+  active                   BOOLEAN NOT NULL DEFAULT TRUE,
+
+  last_run_at              TIMESTAMPTZ,
+  last_run_id              TEXT,                                  -- operator_runs.id of the most recent cycle
+  last_error               TEXT,
+
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_opsubs_user            ON operator_subscriptions (user_id);
+CREATE INDEX IF NOT EXISTS ix_opsubs_active_lastrun  ON operator_subscriptions (active, last_run_at);

--- a/backend/tests/test_operator_scheduler.py
+++ b/backend/tests/test_operator_scheduler.py
@@ -1,0 +1,316 @@
+"""Tests for OperatorSubscription CRUD, due-subscription gating, and the
+``/operator/tick`` + ``/operator/tick/all`` endpoints."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main, operator, store
+
+
+def _stub_agent(monkeypatch, *, raise_exc: Exception | None = None):
+    def fake_run(self, product, platforms, *, research_context=None):
+        if raise_exc is not None:
+            raise raise_exc
+        return {
+            "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+            "posts": {
+                p: {"draft": "raw", "feedback": "f", "final": f"final-{p}"} for p in platforms
+            },
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", fake_run)
+
+
+# ---------------------------------------------------------------------------
+# store CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_list_operator_subscription():
+    uid = "u-sub"
+    sub = store.create_operator_subscription(
+        uid,
+        name="daily",
+        product="a sample product blurb",
+        platforms=["x", "linkedin"],
+    )
+    assert sub["id"]
+    assert sub["interval_hours"] == 24
+    assert sub["active"] is True
+    assert sub["last_run_at"] is None
+
+    listed = store.list_operator_subscriptions(uid)
+    assert [r["id"] for r in listed] == [sub["id"]]
+
+
+def test_create_rejects_bad_interval():
+    with pytest.raises(ValueError):
+        store.create_operator_subscription(
+            "u-bad",
+            name="x",
+            product="a sample product blurb",
+            platforms=["x"],
+            interval_hours=0,
+        )
+
+
+def test_update_operator_subscription_patches_fields():
+    uid = "u-up"
+    sub = store.create_operator_subscription(
+        uid,
+        name="orig",
+        product="a sample product blurb",
+        platforms=["x"],
+    )
+    out = store.update_operator_subscription(
+        uid,
+        sub["id"],
+        name="renamed",
+        platforms=["x", "linkedin"],
+        active=False,
+    )
+    assert out["name"] == "renamed"
+    assert out["platforms"] == ["x", "linkedin"]
+    assert out["active"] is False
+
+
+def test_update_operator_subscription_owners_only():
+    other = store.create_operator_subscription(
+        "user-other",
+        name="x",
+        product="a sample product blurb",
+        platforms=["x"],
+    )
+    assert store.update_operator_subscription("user-A", other["id"], name="hijack") is None
+
+
+def test_delete_operator_subscription():
+    uid = "u-del"
+    sub = store.create_operator_subscription(
+        uid, name="x", product="a sample product blurb", platforms=["x"]
+    )
+    assert store.delete_operator_subscription(uid, sub["id"]) is True
+    assert store.delete_operator_subscription(uid, sub["id"]) is False  # second delete = no-op
+
+
+# ---------------------------------------------------------------------------
+# due_operator_subscriptions
+# ---------------------------------------------------------------------------
+
+
+def test_due_subscriptions_includes_never_run():
+    uid = "u-due"
+    sub = store.create_operator_subscription(
+        uid, name="x", product="a sample product blurb", platforms=["x"]
+    )
+    due = store.due_operator_subscriptions(user_id=uid)
+    assert [r["id"] for r in due] == [sub["id"]]
+
+
+def test_due_subscriptions_skips_recent_run():
+    uid = "u-recent"
+    sub = store.create_operator_subscription(
+        uid,
+        name="hourly",
+        product="a sample product blurb",
+        platforms=["x"],
+        interval_hours=24,
+    )
+    # Ran 1 hour ago → not yet due for a 24h interval.
+    store.mark_operator_subscription_run(
+        sub["id"],
+        run_id="run-x",
+        when=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    due = store.due_operator_subscriptions(user_id=uid)
+    assert due == []
+
+
+def test_due_subscriptions_returns_when_overdue():
+    uid = "u-overdue"
+    sub = store.create_operator_subscription(
+        uid,
+        name="daily",
+        product="a sample product blurb",
+        platforms=["x"],
+        interval_hours=24,
+    )
+    store.mark_operator_subscription_run(
+        sub["id"],
+        run_id="prev",
+        when=datetime.now(timezone.utc) - timedelta(hours=25),
+    )
+    due = store.due_operator_subscriptions(user_id=uid)
+    assert [r["id"] for r in due] == [sub["id"]]
+
+
+def test_due_subscriptions_skips_inactive():
+    uid = "u-off"
+    store.create_operator_subscription(
+        uid, name="x", product="a sample product blurb", platforms=["x"], active=False
+    )
+    assert store.due_operator_subscriptions(user_id=uid) == []
+
+
+def test_due_subscriptions_all_users():
+    """No user filter → walks every active sub regardless of owner."""
+    store.create_operator_subscription("u-a", name="a", product="p" * 20, platforms=["x"])
+    store.create_operator_subscription("u-b", name="b", product="p" * 20, platforms=["x"])
+    all_due = store.due_operator_subscriptions()
+    user_ids = sorted({r["user_id"] for r in all_due})
+    assert user_ids == ["u-a", "u-b"]
+
+
+# ---------------------------------------------------------------------------
+# operator.tick_user / tick_all
+# ---------------------------------------------------------------------------
+
+
+def test_tick_user_fires_each_due_sub(monkeypatch):
+    _stub_agent(monkeypatch)
+    uid = "u-tick"
+    store.create_operator_subscription(uid, name="one", product="p" * 20, platforms=["x"])
+    store.create_operator_subscription(uid, name="two", product="p" * 20, platforms=["linkedin"])
+
+    results = operator.tick_user(uid)
+    assert {r["name"] for r in results} == {"one", "two"}
+    assert all(r["error"] is None for r in results)
+    # All subs now have a last_run_at, so they no longer count as due.
+    assert store.due_operator_subscriptions(user_id=uid) == []
+
+
+def test_tick_user_isolates_failures(monkeypatch):
+    """A subscription that explodes mid-tick does not poison the rest of the
+    batch."""
+    uid = "u-mixed"
+    store.create_operator_subscription(uid, name="good", product="p" * 20, platforms=["x"])
+    bad = store.create_operator_subscription(
+        uid, name="bad", product="p" * 20, platforms=["linkedin"]
+    )
+
+    # Patch: explode only when the "bad" subscription's platforms come through.
+    real_run = main.SocialAgent.run
+
+    def selective_run(self, product, platforms, *, research_context=None):
+        if "linkedin" in platforms and len(platforms) == 1:
+            raise RuntimeError("boom")
+        return {
+            "plan": {"audience": "a", "angle": "b", "key_points": ["c"], "tone": "d", "cta": "e"},
+            "posts": {p: {"draft": "r", "feedback": "f", "final": "f"} for p in platforms},
+        }
+
+    monkeypatch.setattr(main.SocialAgent, "run", selective_run)
+
+    results = operator.tick_user(uid)
+    by_name = {r["name"]: r for r in results}
+    assert by_name["good"]["error"] is None
+    assert by_name["good"]["drafts"] == 1
+    assert "RuntimeError" in (by_name["bad"]["error"] or "")
+    # The bad sub recorded its error onto the subscription row.
+    rows = {r["id"]: r for r in store.list_operator_subscriptions(uid)}
+    assert "RuntimeError" in (rows[bad["id"]]["last_error"] or "")
+
+
+def test_tick_all_walks_every_user(monkeypatch):
+    _stub_agent(monkeypatch)
+    store.create_operator_subscription("u-1", name="one", product="p" * 20, platforms=["x"])
+    store.create_operator_subscription("u-2", name="two", product="p" * 20, platforms=["x"])
+
+    results = operator.tick_all()
+    assert len(results) == 2
+    assert all(r["error"] is None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_crud_endpoints(monkeypatch):
+    _stub_agent(monkeypatch)
+    client = TestClient(main.app)
+
+    # Create
+    res = client.post(
+        "/operator/subscriptions",
+        json={"name": "daily", "product": "p" * 20, "platforms": ["x"]},
+    )
+    assert res.status_code == 201
+    sub = res.json()
+    sub_id = sub["id"]
+
+    # List
+    res = client.get("/operator/subscriptions")
+    assert [r["id"] for r in res.json()] == [sub_id]
+
+    # Update
+    res = client.patch(f"/operator/subscriptions/{sub_id}", json={"active": False})
+    assert res.status_code == 200
+    assert res.json()["active"] is False
+
+    # Delete
+    res = client.delete(f"/operator/subscriptions/{sub_id}")
+    assert res.status_code == 200
+    assert client.get("/operator/subscriptions").json() == []
+
+
+def test_subscription_create_rejects_invalid_platform(monkeypatch):
+    client = TestClient(main.app)
+    res = client.post(
+        "/operator/subscriptions",
+        json={"name": "x", "product": "p" * 20, "platforms": ["nope"]},
+    )
+    assert res.status_code == 400
+
+
+def test_subscription_update_404_for_unknown():
+    client = TestClient(main.app)
+    res = client.patch("/operator/subscriptions/does-not-exist", json={"active": False})
+    assert res.status_code == 404
+
+
+def test_tick_endpoint_runs_due_subs(monkeypatch):
+    _stub_agent(monkeypatch)
+    client = TestClient(main.app)
+    client.post(
+        "/operator/subscriptions",
+        json={"name": "x", "product": "p" * 20, "platforms": ["x"]},
+    )
+    res = client.post("/operator/tick")
+    assert res.status_code == 200
+    ran = res.json()["ran"]
+    assert len(ran) == 1
+    assert ran[0]["error"] is None
+
+
+def test_tick_all_403_when_secret_unset(monkeypatch):
+    monkeypatch.delenv("OPERATOR_TICK_SECRET", raising=False)
+    client = TestClient(main.app)
+    res = client.post("/operator/tick/all", headers={"X-Tick-Secret": "anything"})
+    assert res.status_code == 403
+
+
+def test_tick_all_403_on_bad_secret(monkeypatch):
+    monkeypatch.setenv("OPERATOR_TICK_SECRET", "expected")
+    client = TestClient(main.app)
+    res = client.post("/operator/tick/all", headers={"X-Tick-Secret": "wrong"})
+    assert res.status_code == 403
+
+
+def test_tick_all_runs_when_secret_matches(monkeypatch):
+    monkeypatch.setenv("OPERATOR_TICK_SECRET", "right")
+    _stub_agent(monkeypatch)
+    # Set up a sub belonging to a different user so user-scoped tick wouldn't
+    # see it but service tick does.
+    store.create_operator_subscription(
+        "user-other", name="x", product="p" * 20, platforms=["x"]
+    )
+    client = TestClient(main.app)
+    res = client.post("/operator/tick/all", headers={"X-Tick-Secret": "right"})
+    assert res.status_code == 200
+    assert len(res.json()["ran"]) == 1

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -77,24 +77,87 @@ showing in a UI:
 - `"cold-start (no leaderboard yet); 5 top-score snippets fed 4 drafts"`
 - `"cold-start (no banked snippets); 4 drafts produced ungrounded"`
 
+## Operator subscriptions (autonomous mode)
+
+For the loop to be truly autonomous you don't want to hand-roll a cron
+that calls `/operator/run` — you want stored configs that the backend
+walks on a cadence, the same way research subscriptions work.  That is
+`operator_subscriptions`.
+
+### Shape
+
+Each subscription is `(name, product, platforms, interval_hours,
+weight_by_leaderboard, leaderboard_metric, snippet_limit, active)`.
+`last_run_at` gates the cron so a sub only fires when
+`now - last_run_at >= interval_hours`; a freshly-created sub with
+`last_run_at = NULL` is considered due immediately.
+
+### Endpoints
+
+```bash
+# CRUD
+curl -s -X POST  http://localhost:8000/operator/subscriptions \
+     -d '{"name":"daily-x-linkedin","product":"<blurb>","platforms":["x","linkedin"]}'
+curl -s          http://localhost:8000/operator/subscriptions
+curl -s -X PATCH http://localhost:8000/operator/subscriptions/<id> -d '{"active":false}'
+curl -s -X DELETE http://localhost:8000/operator/subscriptions/<id>
+
+# Manual fire — runs every sub belonging to the authed user that is due now
+curl -s -X POST http://localhost:8000/operator/tick
+
+# Service-auth fan-out — used by the hourly GitHub Action; off by default
+curl -s -X POST http://localhost:8000/operator/tick/all \
+     -H "X-Tick-Secret: $OPERATOR_TICK_SECRET"
+```
+
+### Cron wiring
+
+`.github/workflows/operator-tick.yml` is the recommended driver.  It is
+off by default; turn it on by setting:
+
+```
+REPO VARIABLE  OPERATOR_TICK_ENABLED = "true"
+REPO SECRET    OPERATOR_TICK_URL     = "https://api.example.com/operator/tick/all"
+REPO SECRET    OPERATOR_TICK_SECRET  = "<same value as backend env>"
+```
+
+The workflow hits `/operator/tick/all` hourly (minute :37, deliberately
+offset from research-tick at :17 so they don't fight for backend
+attention).  Failures log a warning and exit 0 — a flaky backend should
+not redden the repo's CI badge.
+
+### Error isolation
+
+`tick_all` walks every due subscription in sequence.  A subscription
+that raises mid-cycle gets its `last_error` stamped, but the remaining
+subscriptions in the batch still run — one broken product blurb cannot
+silence the whole fleet.
+
 ## Pairing with cron
 
-There is no built-in operator scheduler yet — drive `/operator/run` from
-the same hourly cron that already runs `/research/tick/all` if you want
-the loop to be fully autonomous.  Recommended sequence:
+Recommended sequence on a single host:
 
-1. `/research/tick/all`   — pull fresh signals
-2. `/operator/run`        — pick + draft
+1. `/research/tick/all`   — pull fresh signals (`:17 * * * *`)
+2. `/operator/tick/all`   — pick + draft per subscription (`:37 * * * *`)
 3. extension polls `/queue` → posts → reports outcomes
 
 ## Where the code lives
 
-- `backend/app/operator.py` — `operator.run(uid, ...)` end-to-end driver
+- `backend/app/operator.py` — `operator.run(uid, ...)` end-to-end driver,
+  `operator.tick_user(uid)`, `operator.tick_all()`
 - `backend/app/store.py` — `select_experiment_snippets`,
   `start_operator_run`, `complete_operator_run`, `fail_operator_run`,
-  `list_operator_runs`, `get_operator_run`
-- `backend/app/models.py` — `OperatorRun` SQLAlchemy model
-- `backend/migrations/006_operator_runs.sql`
+  `list_operator_runs`, `get_operator_run`, plus subscription CRUD
+  (`create_operator_subscription`, `list_operator_subscriptions`,
+  `update_operator_subscription`, `delete_operator_subscription`,
+  `due_operator_subscriptions`, `mark_operator_subscription_run`)
+- `backend/app/models.py` — `OperatorRun` + `OperatorSubscription`
+- `backend/migrations/006_operator_runs.sql`,
+  `backend/migrations/007_operator_subscriptions.sql`
 - `backend/app/main.py` — `/operator/run`, `/operator/runs`,
-  `/operator/runs/{run_id}`
-- `web/lib/api.ts` — `api.operator.{run,list,get}` typed client
+  `/operator/runs/{run_id}`, `/operator/subscriptions` CRUD,
+  `/operator/tick`, `/operator/tick/all`
+- `.github/workflows/operator-tick.yml` — hourly cron driver
+- `web/lib/api.ts` — `api.operator.{run,list,get}`,
+  `api.operator.subscriptions.{list,create,update,remove}`,
+  `api.operator.tick()`

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -186,6 +186,54 @@ export const api = {
       }),
     list: (limit = 20) => request<OperatorRun[]>(`/operator/runs?limit=${limit}`),
     get: (runId: string) => request<OperatorRun>(`/operator/runs/${runId}`),
+
+    subscriptions: {
+      list: () => request<OperatorSubscription[]>("/operator/subscriptions"),
+      create: (input: {
+        name: string;
+        product: string;
+        platforms?: Platform[];
+        weight_by_leaderboard?: boolean;
+        leaderboard_metric?: OutcomeMetric;
+        snippet_limit?: number;
+        interval_hours?: number;
+        active?: boolean;
+      }) =>
+        request<OperatorSubscription>("/operator/subscriptions", {
+          method: "POST",
+          body: JSON.stringify(input),
+        }),
+      update: (id: string, patch: Partial<{
+        name: string;
+        product: string;
+        platforms: Platform[];
+        weight_by_leaderboard: boolean;
+        leaderboard_metric: OutcomeMetric;
+        snippet_limit: number;
+        interval_hours: number;
+        active: boolean;
+      }>) =>
+        request<OperatorSubscription>(`/operator/subscriptions/${id}`, {
+          method: "PATCH",
+          body: JSON.stringify(patch),
+        }),
+      remove: (id: string) =>
+        request<{ deleted: string }>(`/operator/subscriptions/${id}`, {
+          method: "DELETE",
+        }),
+    },
+
+    tick: () =>
+      request<{
+        ran: {
+          subscription_id: string;
+          name: string;
+          run_id: string | null;
+          drafts: number;
+          leaderboard_used: boolean;
+          error: string | null;
+        }[];
+      }>("/operator/tick", { method: "POST" }),
   },
 };
 
@@ -302,4 +350,21 @@ export type OperatorRun = {
   notes: string | null;
   started_at: string;
   completed_at: string | null;
+};
+
+export type OperatorSubscription = {
+  id: string;
+  user_id: string;
+  name: string;
+  product: string;
+  platforms: Platform[];
+  weight_by_leaderboard: boolean;
+  leaderboard_metric: string;
+  snippet_limit: number;
+  interval_hours: number;
+  active: boolean;
+  last_run_at: string | null;
+  last_run_id: string | null;
+  last_error: string | null;
+  created_at: string;
 };


### PR DESCRIPTION
Closes the last gap left by #57/#58/#59 — the operator can now run on a
cadence without anyone manually POSTing.  Same shape as research
subscriptions, designed to ride alongside the existing research-tick
cron.

## What

- **Migration 007**: `operator_subscriptions`. Stored config per user
  (product, platforms, interval_hours, weighting flag, active).
  `last_run_at` + `last_run_id` gate the cron and link audit rows back
  to `operator_runs`.
- **Store helpers**: full CRUD + `due_operator_subscriptions` (cross-DB
  Python-side recency check) + `mark_operator_subscription_run`.
- **`operator.tick_user(uid)` / `operator.tick_all()`** — walk due
  subscriptions and fire one `operator.run` cycle each.
  **Per-subscription error isolation**: a bad blurb taints its
  `last_error` but the rest of the batch still runs.
- **HTTP:**
  - `POST /operator/subscriptions`, list/patch/delete — CRUD
  - `POST /operator/tick` — user-scoped manual fire
  - `POST /operator/tick/all` — service-auth fan-out, gated on
    `OPERATOR_TICK_SECRET` (403 by default)
- **GitHub Action** `.github/workflows/operator-tick.yml` — hourly at
  minute 37 (offset from research-tick at :17). Summary in
  `GITHUB_STEP_SUMMARY`. Off by default — enable with
  `OPERATOR_TICK_ENABLED=true` repo variable + URL/secret pair.
- **Typed web client**: `api.operator.subscriptions.{list,create,update,remove}`,
  `api.operator.tick()`, `OperatorSubscription` type.
- **docs/OPERATOR.md** gains an 'Operator subscriptions (autonomous
  mode)' section with the cron recipe and error-isolation note.

## Why this closes the loop

#57 brought signals in. #58 collected outcomes. #59 made the operator
pick + draft based on those outcomes. This PR is the wiring that makes
all of that **happen on a clock**:

```
research-tick (:17 hourly)  →  banks fresh snippets
operator-tick (:37 hourly)  →  picks + drafts per subscription
extension polls /queue      →  posts via user's browser
extension POSTs outcomes    →  feeds the leaderboard
research-tick next hour     →  picks bias toward winners
```

## Tests

- 20 new in `tests/test_operator_scheduler.py`:
  - CRUD happy + owner-only paths
  - Due-subscription gating: never-run, recent, overdue, inactive
  - `tick_user` / `tick_all` with stubbed agent
  - **Error isolation**: a sub that explodes mid-tick leaves the rest of
    the batch running and the failed sub's `last_error` populated.
  - HTTP layer: full CRUD, tick endpoints, `OPERATOR_TICK_SECRET` 403
    paths.
- Full backend pytest: **104/104 pass.**
- Web `tsc --noEmit`: clean.