### PR TITLE
feat(extension): outcome-puller — close the autonomy loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,4 +117,18 @@ jobs:
                   assert os.path.exists(js), f"missing file: {js}"
           assert os.path.exists(m["background"]["service_worker"])
           print("OK — all referenced files exist")
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Syntax-check JS sources
+        # Node --check parses without executing; flags syntactic issues a
+        # Chrome-load would otherwise hide behind silent failure.
+        run: |
+          for f in src/*.js; do node --check "$f" || exit 1; done
+          echo "OK — all JS files parse cleanly"
+
+      - name: Run outcome-extractor tests
+        run: node tests/test_outcomes.mjs
           PY

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Fanout Poster",
-  "version": "0.4.2",
-  "description": "Posts Fanout drafts to LinkedIn, X, Threads, Bluesky, Mastodon, Instagram, Reddit, and more — from your own browser session.",
+  "version": "0.5.0",
+  "description": "Posts Fanout drafts to LinkedIn, X, Threads, Bluesky, Mastodon, Instagram, Reddit, and more — from your own browser session. Optionally scrapes engagement metrics off posted-draft URLs to feed the operator leaderboard.",
   "permissions": [
     "storage",
     "alarms",

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -2,6 +2,14 @@
 
 const DEFAULT_API = "http://localhost:8000";
 const POLL_ALARM = "fanout-poll";
+// Outcome-puller is a separate alarm so it can run on a slower cadence
+// than the queue poll (engagement metrics evolve over hours, not seconds).
+const OUTCOMES_ALARM = "fanout-outcomes";
+const OUTCOMES_DEFAULT_MINUTES = 60;
+// Cap the per-cycle work so a backlog of "posted" drafts can't burn a
+// browser session opening hundreds of tabs at once.
+const OUTCOMES_MAX_PER_CYCLE = 8;
+const OUTCOMES_TAB_TIMEOUT_MS = 20000;
 
 // Per-platform routing: which tab pattern to find/open, OR which compose URL to open
 // for "copy & open" platforms that the extension can't fully drive.
@@ -40,11 +48,29 @@ const PLATFORM_TARGETS = {
 };
 
 async function getConfig() {
-  const { apiUrl, enabled, jwt } = await chrome.storage.local.get(["apiUrl", "enabled", "jwt"]);
+  const {
+    apiUrl,
+    enabled,
+    jwt,
+    outcomesEnabled,
+    outcomesIntervalMinutes,
+  } = await chrome.storage.local.get([
+    "apiUrl",
+    "enabled",
+    "jwt",
+    "outcomesEnabled",
+    "outcomesIntervalMinutes",
+  ]);
   return {
     apiUrl: apiUrl || DEFAULT_API,
     enabled: enabled !== false,
     jwt: jwt || "",
+    // Outcome-pulling is OFF by default — the user has to opt in via the
+    // popup. We don't want to open background tabs to a user's social
+    // pages without their explicit consent.
+    outcomesEnabled: outcomesEnabled === true,
+    outcomesIntervalMinutes:
+      Number(outcomesIntervalMinutes) > 0 ? Number(outcomesIntervalMinutes) : OUTCOMES_DEFAULT_MINUTES,
   };
 }
 
@@ -211,19 +237,126 @@ async function poll() {
   }
 }
 
-chrome.runtime.onInstalled.addListener(() => {
+// ---------------------------------------------------------------------------
+// Outcome puller — scrape engagement metrics off posted-draft URLs and
+// POST them to /drafts/{id}/outcomes so the leaderboard fills.
+// ---------------------------------------------------------------------------
+
+async function reportOutcome(apiUrl, jwt, draftId, kind, value) {
+  try {
+    await fetch(`${apiUrl}/drafts/${encodeURIComponent(draftId)}/outcomes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders(jwt) },
+      body: JSON.stringify({ metric_kind: kind, metric_value: value }),
+    });
+  } catch (e) {
+    console.warn(`Fanout: outcome report failed (${kind}=${value})`, e);
+  }
+}
+
+async function extractMetricsFromTab(tabId) {
+  try {
+    // Two-step: inject outcomes.js (it sets window.__fanoutExtractMetrics),
+    // then call it. Keeping the extractor in its own file means we can
+    // ship updates without touching the worker.
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["src/outcomes.js"],
+    });
+    const [res] = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => (window.__fanoutExtractMetrics ? window.__fanoutExtractMetrics() : null),
+    });
+    return res?.result || null;
+  } catch (e) {
+    console.warn("Fanout: extractMetrics failed", e);
+    return null;
+  }
+}
+
+async function pullOutcomesForDraft(apiUrl, jwt, draft) {
+  if (!draft?.post_url) return { draft_id: draft?.id, skipped: "no post_url" };
+  const tab = await chrome.tabs.create({ url: draft.post_url, active: false });
+  let result = null;
+  try {
+    await waitForTabLoad(tab.id, { timeout: OUTCOMES_TAB_TIMEOUT_MS });
+    // Brief settle so SPA-style platforms finish painting engagement counts.
+    await new Promise((r) => setTimeout(r, 1500));
+    result = await extractMetricsFromTab(tab.id);
+  } finally {
+    // Always close — even on extraction failure we don't want stray tabs.
+    try {
+      await chrome.tabs.remove(tab.id);
+    } catch {
+      /* tab already gone */
+    }
+  }
+  const metrics = result?.metrics || {};
+  const reported = {};
+  for (const [kind, value] of Object.entries(metrics)) {
+    if (typeof value !== "number" || value < 0) continue;
+    await reportOutcome(apiUrl, jwt, draft.id, kind, value);
+    reported[kind] = value;
+  }
+  return { draft_id: draft.id, source: result?.source || "none", reported };
+}
+
+async function pollOutcomes() {
+  const { apiUrl, jwt, outcomesEnabled } = await getConfig();
+  if (!outcomesEnabled) return { ran: false, reason: "outcomes-disabled" };
+  let drafts;
+  try {
+    const res = await fetch(`${apiUrl}/drafts?status=posted`, { headers: authHeaders(jwt) });
+    if (!res.ok) return { ran: false, reason: `HTTP ${res.status}` };
+    drafts = await res.json();
+  } catch (e) {
+    return { ran: false, reason: `fetch-failed: ${e?.message ?? e}` };
+  }
+  const eligible = (drafts || []).filter((d) => d.post_url);
+  const batch = eligible.slice(0, OUTCOMES_MAX_PER_CYCLE);
+  const results = [];
+  for (const draft of batch) {
+    try {
+      results.push(await pullOutcomesForDraft(apiUrl, jwt, draft));
+    } catch (e) {
+      results.push({ draft_id: draft.id, error: String(e?.message ?? e) });
+    }
+  }
+  return { ran: true, total_posted: eligible.length, processed: results };
+}
+
+async function scheduleAlarms() {
+  const { outcomesIntervalMinutes } = await getConfig();
   chrome.alarms.create(POLL_ALARM, { periodInMinutes: 0.5 });
+  chrome.alarms.create(OUTCOMES_ALARM, {
+    delayInMinutes: outcomesIntervalMinutes,
+    periodInMinutes: outcomesIntervalMinutes,
+  });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  void scheduleAlarms();
 });
 chrome.runtime.onStartup.addListener(() => {
-  chrome.alarms.create(POLL_ALARM, { periodInMinutes: 0.5 });
+  void scheduleAlarms();
 });
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === POLL_ALARM) poll();
+  if (alarm.name === OUTCOMES_ALARM) pollOutcomes();
 });
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type === "fanout:poll-now") {
     poll().then(() => sendResponse({ ok: true }));
+    return true;
+  }
+  if (msg?.type === "fanout:outcomes-now") {
+    pollOutcomes().then((out) => sendResponse({ ok: true, ...out }));
+    return true;
+  }
+  if (msg?.type === "fanout:reschedule-outcomes") {
+    // Called by the popup when the user changes the interval setting.
+    scheduleAlarms().then(() => sendResponse({ ok: true }));
     return true;
   }
 });

--- a/extension/src/outcomes.js
+++ b/extension/src/outcomes.js
@@ -1,0 +1,115 @@
+// Engagement-metric extractor — injected into the open post page via
+// chrome.scripting.executeScript. Runs in the page's isolated world and
+// returns a plain object the background worker turns into outcome rows.
+//
+// Strategy: prefer aria-label patterns first (X / Bluesky / Threads use
+// data-testid + aria-label idioms that are stable across redesigns), then
+// fall back to scanning visible text for `<NUMBER> <metric-word>` pairs.
+// Text-scanning is platform-agnostic so it works for Mastodon, LinkedIn,
+// and any platform we add later without selector maintenance.
+//
+// Returns: { metrics: { likes, comments, reposts, views, ... }, source }
+// where each metric is an integer (already normalized from "1.2K" / "1,234")
+// and ``source`` is a short string explaining which extractor matched.
+
+(function () {
+  const METRIC_WORDS = {
+    likes: ["like", "likes", "favorite", "favorites", "favourite", "favourites"],
+    comments: ["comment", "comments", "reply", "replies"],
+    reposts: ["repost", "reposts", "retweet", "retweets", "boost", "boosts", "reblog", "reblogs", "share", "shares"],
+    views: ["view", "views", "impression", "impressions"],
+    clicks: ["click", "clicks", "tap", "taps"],
+    saves: ["save", "saves", "bookmark", "bookmarks"],
+  };
+
+  function parseCount(raw) {
+    if (raw == null) return null;
+    const s = String(raw).trim().replace(/,/g, "");
+    const m = s.match(/^(\d+(?:\.\d+)?)([KkMmBb])?$/);
+    if (!m) return null;
+    const n = parseFloat(m[1]);
+    const mul = ({ K: 1e3, M: 1e6, B: 1e9 })[(m[2] || "").toUpperCase()] || 1;
+    return Math.round(n * mul);
+  }
+
+  // Walk every aria-label on the page; if it looks like "<number> <metric>"
+  // record the max value per kind. Max is the safest reducer when the same
+  // page may show the metric in multiple places (button + tooltip).
+  function fromAriaLabels() {
+    const out = {};
+    const nodes = document.querySelectorAll("[aria-label]");
+    for (const node of nodes) {
+      const label = node.getAttribute("aria-label") || "";
+      // Match "1,234 likes" / "1.2K views" / "12 replies" anywhere in the label.
+      const matches = label.match(/(\d+(?:[,.]\d+)*[KkMmBb]?)\s+([a-zA-Z]+)/g) || [];
+      for (const m of matches) {
+        const parts = m.match(/(\d+(?:[,.]\d+)*[KkMmBb]?)\s+([a-zA-Z]+)/);
+        if (!parts) continue;
+        const value = parseCount(parts[1]);
+        if (value == null) continue;
+        const word = parts[2].toLowerCase();
+        for (const [kind, words] of Object.entries(METRIC_WORDS)) {
+          if (words.includes(word) && (out[kind] == null || value > out[kind])) {
+            out[kind] = value;
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  // Text fallback — scan innerText for "<NUMBER> <metric-word>" pairs.
+  function fromVisibleText() {
+    const out = {};
+    const text = (document.body && document.body.innerText) || "";
+    // Limit scan: a busy feed page can have thousands of these; we only
+    // want the ones near the post we're inspecting. URL-based filtering
+    // happens at the background-worker level (we open the post's own URL),
+    // so the first dozen matches on the page are usually the right ones.
+    const re = /(\d+(?:[,.]\d+)*[KkMmBb]?)\s+([a-zA-Z]+)/g;
+    let m;
+    let scanned = 0;
+    while ((m = re.exec(text)) !== null && scanned < 200) {
+      scanned++;
+      const value = parseCount(m[1]);
+      if (value == null) continue;
+      const word = m[2].toLowerCase();
+      for (const [kind, words] of Object.entries(METRIC_WORDS)) {
+        if (words.includes(word) && (out[kind] == null || value > out[kind])) {
+          out[kind] = value;
+        }
+      }
+    }
+    return out;
+  }
+
+  function merge(primary, secondary) {
+    const out = { ...secondary, ...primary };
+    // Prefer the larger value when both extractors found the kind: the page
+    // typically renders the more accurate count in the aria-label and a
+    // shorter "12K" rounded form in visible text. Take max to avoid losing
+    // precision.
+    for (const k of Object.keys(out)) {
+      const a = primary[k];
+      const b = secondary[k];
+      if (a != null && b != null) out[k] = Math.max(a, b);
+    }
+    return out;
+  }
+
+  function extract() {
+    const aria = fromAriaLabels();
+    const text = fromVisibleText();
+    const metrics = merge(aria, text);
+    let source = "none";
+    if (Object.keys(aria).length > 0 && Object.keys(text).length > 0) source = "aria+text";
+    else if (Object.keys(aria).length > 0) source = "aria";
+    else if (Object.keys(text).length > 0) source = "text";
+    return { metrics, source };
+  }
+
+  // Expose for both direct injection via `func:` and content_scripts loading.
+  // chrome.scripting.executeScript with `files:` runs this module top-level;
+  // background.js then calls window.__fanoutExtractMetrics().
+  window.__fanoutExtractMetrics = extract;
+})();

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -4,14 +4,20 @@
     <meta charset="utf-8" />
     <title>Fanout</title>
     <style>
-      body { font-family: system-ui, sans-serif; width: 320px; padding: 12px; }
+      body { font-family: system-ui, sans-serif; width: 340px; padding: 12px; }
       h1 { margin: 0 0 8px 0; font-size: 16px; }
+      h2 { margin: 14px 0 6px 0; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: #666; }
       label { display: block; font-size: 12px; margin-top: 8px; }
-      input[type="text"], textarea { width: 100%; padding: 6px; box-sizing: border-box; font-family: monospace; font-size: 11px; }
+      input[type="text"], input[type="number"], textarea {
+        width: 100%; padding: 6px; box-sizing: border-box;
+        font-family: monospace; font-size: 11px;
+      }
       textarea { height: 60px; resize: vertical; }
       button { margin-top: 10px; padding: 6px 10px; }
       .row { display: flex; align-items: center; gap: 6px; margin-top: 8px; }
+      .row input[type="number"] { width: 60px; }
       .muted { color: #888; font-size: 11px; margin-top: 12px; }
+      hr { border: 0; border-top: 1px solid #eee; margin: 12px 0 0 0; }
     </style>
   </head>
   <body>
@@ -26,10 +32,29 @@
     </label>
     <div class="row">
       <input id="enabled" type="checkbox" />
-      <label for="enabled" style="margin:0">Enabled (poll every 30s)</label>
+      <label for="enabled" style="margin:0">Poll queue (every 30s)</label>
     </div>
+
+    <hr />
+    <h2>Outcome feedback</h2>
+    <p class="muted" style="margin-top:0">
+      Opens posted-draft URLs in background tabs to scrape engagement
+      metrics (likes / replies / reposts / views) and feed them back to
+      the leaderboard. Off by default.
+    </p>
+    <div class="row">
+      <input id="outcomesEnabled" type="checkbox" />
+      <label for="outcomesEnabled" style="margin:0">Enable outcome polling</label>
+    </div>
+    <label>
+      Interval (minutes between scrapes)
+      <input id="outcomesInterval" type="number" min="5" step="5" value="60" />
+    </label>
+
+    <hr />
     <button id="save">Save</button>
-    <button id="pollNow">Poll now</button>
+    <button id="pollNow">Poll queue now</button>
+    <button id="outcomesNow">Pull outcomes now</button>
     <p id="status" class="muted"></p>
     <script src="popup.js"></script>
   </body>

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -1,32 +1,65 @@
 const apiInput = document.getElementById("apiUrl");
 const jwtInput = document.getElementById("jwt");
 const enabledInput = document.getElementById("enabled");
+const outcomesEnabledInput = document.getElementById("outcomesEnabled");
+const outcomesIntervalInput = document.getElementById("outcomesInterval");
 const status = document.getElementById("status");
 
 async function load() {
-  const { apiUrl, enabled, jwt } = await chrome.storage.local.get([
+  const {
+    apiUrl,
+    enabled,
+    jwt,
+    outcomesEnabled,
+    outcomesIntervalMinutes,
+  } = await chrome.storage.local.get([
     "apiUrl",
     "enabled",
     "jwt",
+    "outcomesEnabled",
+    "outcomesIntervalMinutes",
   ]);
   apiInput.value = apiUrl || "http://localhost:8000";
   jwtInput.value = jwt || "";
   enabledInput.checked = enabled !== false;
+  outcomesEnabledInput.checked = outcomesEnabled === true;
+  outcomesIntervalInput.value = Number(outcomesIntervalMinutes) > 0 ? outcomesIntervalMinutes : 60;
 }
 
 document.getElementById("save").addEventListener("click", async () => {
+  // Clamp interval — Chrome alarms can't fire faster than every minute,
+  // and the engagement metrics we're scraping barely move in under five.
+  const raw = parseInt(outcomesIntervalInput.value, 10);
+  const interval = Number.isFinite(raw) && raw >= 5 ? raw : 60;
   await chrome.storage.local.set({
     apiUrl: apiInput.value.trim(),
     jwt: jwtInput.value.trim(),
     enabled: enabledInput.checked,
+    outcomesEnabled: outcomesEnabledInput.checked,
+    outcomesIntervalMinutes: interval,
   });
+  // Re-arm the outcomes alarm so the new interval takes effect immediately
+  // instead of waiting for the next browser restart.
+  await chrome.runtime.sendMessage({ type: "fanout:reschedule-outcomes" });
   status.textContent = "Saved.";
 });
 
 document.getElementById("pollNow").addEventListener("click", async () => {
-  status.textContent = "Polling...";
+  status.textContent = "Polling queue...";
   await chrome.runtime.sendMessage({ type: "fanout:poll-now" });
   status.textContent = "Done.";
+});
+
+document.getElementById("outcomesNow").addEventListener("click", async () => {
+  status.textContent = "Pulling outcomes...";
+  const out = await chrome.runtime.sendMessage({ type: "fanout:outcomes-now" });
+  if (!out?.ran) {
+    status.textContent = `Skipped: ${out?.reason ?? "unknown"}`;
+    return;
+  }
+  const processed = Array.isArray(out.processed) ? out.processed : [];
+  const reported = processed.filter((p) => p.reported && Object.keys(p.reported).length > 0);
+  status.textContent = `Scraped ${processed.length} of ${out.total_posted} posted; ${reported.length} produced metrics.`;
 });
 
 load();

--- a/extension/tests/test_outcomes.mjs
+++ b/extension/tests/test_outcomes.mjs
@@ -1,0 +1,92 @@
+// Smoke tests for the outcome-metric extractor. Stubs a minimal DOM so
+// outcomes.js can run under plain `node` (no jsdom dep). Add fixtures
+// here whenever you wire a new platform.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, "../src/outcomes.js"), "utf8");
+
+function runFixture(ariaLabels, text) {
+  const ariaNodes = ariaLabels.map((label) => ({ getAttribute: () => label }));
+  globalThis.window = {};
+  globalThis.document = {
+    querySelectorAll: (sel) => (sel.includes("aria-label") ? ariaNodes : []),
+    body: { innerText: text },
+  };
+  // Re-eval each time so the IIFE freshly rebinds window.__fanoutExtractMetrics.
+  // eslint-disable-next-line no-eval
+  eval(src);
+  return globalThis.window.__fanoutExtractMetrics();
+}
+
+let failures = 0;
+function assert(cond, label, ctx) {
+  if (!cond) {
+    failures++;
+    console.error("FAIL:", label, ctx);
+  }
+}
+
+// --- X (Twitter) — aria-labels carry the precise counts ----------------------
+const x = runFixture(
+  ["1,234 likes", "56 replies", "1.2K reposts", "12,345 views"],
+  ""
+);
+assert(x.metrics.likes === 1234, "x likes", x);
+assert(x.metrics.comments === 56, "x comments", x);
+assert(x.metrics.reposts === 1200, "x reposts", x);
+assert(x.metrics.views === 12345, "x views", x);
+assert(x.source === "aria", "x source", x.source);
+
+// --- LinkedIn — visible-text scan -------------------------------------------
+const li = runFixture(
+  [],
+  "Joe Lee and 47 others 12 comments 3 reposts"
+);
+assert(li.metrics.comments === 12, "li comments", li);
+assert(li.metrics.reposts === 3, "li reposts", li);
+
+// --- Bluesky — "23 likes 7 reposts 4 replies" -------------------------------
+const bsky = runFixture([], "23 likes 7 reposts 4 replies");
+assert(bsky.metrics.likes === 23, "bsky likes", bsky);
+assert(bsky.metrics.reposts === 7, "bsky reposts", bsky);
+assert(bsky.metrics.comments === 4, "bsky comments", bsky);
+
+// --- Mastodon — "favorites" + "boosts" aliases ------------------------------
+const mast = runFixture([], "5 favorites 2 boosts 1 reply");
+assert(mast.metrics.likes === 5, "mast favorites→likes", mast);
+assert(mast.metrics.reposts === 2, "mast boosts→reposts", mast);
+assert(mast.metrics.comments === 1, "mast reply→comments", mast);
+
+// --- K/M suffix normalization -----------------------------------------------
+const kn = runFixture(["1.5K likes"], "");
+assert(kn.metrics.likes === 1500, "kn 1.5K", kn);
+
+// --- Empty page → empty metrics --------------------------------------------
+const empty = runFixture(["Profile"], "Welcome back");
+assert(
+  Object.keys(empty.metrics).length === 0,
+  "empty page returns no metrics",
+  empty
+);
+
+// --- Max-wins: aria=1234, text=1.2K → keep 1234 -----------------------------
+const both = runFixture(["1,234 likes"], "1.2K likes");
+assert(both.metrics.likes === 1234, "both: max wins", both);
+
+// --- Bogus word: number adjacent to a non-metric word → no metric -----------
+const bogus = runFixture([], "42 frobozz");
+assert(
+  Object.keys(bogus.metrics).length === 0,
+  "bogus word does not register",
+  bogus
+);
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log("OK — all outcome-extraction fixtures pass");


### PR DESCRIPTION
Closes the last gap: until now the leaderboard from #58 needed someone
to manually call \`POST /drafts/{id}/outcomes\`. This wires the
extension to do it on a cadence from posted-draft URLs the user has
already shipped, completing the self-tuning loop:

\`\`\`
research-tick (:17 hourly) ──► fresh signals banked
operator-tick (:37 hourly) ──► picks + drafts per subscription
extension polls /queue     ──► posts via the user's browser
outcome puller (:60 min)   ──► scrapes engagement, POSTs to /drafts/{id}/outcomes  ← THIS PR
                                              │
                                              ▼
                                  next research tick weights picks
                                  toward sources with engagement
\`\`\`

## What

- **\`extension/src/outcomes.js\`** — DOM-agnostic metric extractor.
  Two-pass: aria-label scan first (X / Bluesky / Threads carry exact
  counts), then visible-text fallback (LinkedIn / Mastodon / anything
  new). Max of both wins. Normalizes 1,234 / 1.2K / 1.5M / 1B to an
  int. Open metric vocabulary — recognizes likes/favorites,
  comments/replies, reposts/retweets/boosts/reblogs/shares,
  views/impressions, clicks/taps, saves/bookmarks.
- **background.js** — new \`OUTCOMES_ALARM\`, separate cadence (default
  60 min). \`pullOutcomesForDraft\` opens the post URL in a background
  tab, injects the extractor, POSTs each detected metric to
  \`/drafts/{id}/outcomes\`, closes the tab in a \`finally\` even on
  extractor failure. Per-cycle cap of 8 tabs.
- **Popup** — new 'Outcome feedback' section: enable/disable toggle +
  minutes-per-scrape input (clamped to >= 5). 'Pull outcomes now' for
  manual trigger. Saving reschedules the alarm so a new interval takes
  effect immediately.
- **Defaults**: outcome pulling is OFF until the user opts in via the
  popup. Opening background tabs to a user's social pages without
  explicit consent is intentionally avoided.

## Tests

- \`extension/tests/test_outcomes.mjs\` — pure-Node smoke test. Stubs a
  minimal DOM and runs the extractor against 8 platform fixtures
  (X aria-labels, LinkedIn text scan, Bluesky/Mastodon variants,
  K/M normalization, empty/bogus inputs, aria+text max-wins).
- CI's Extension job now also \`node --check\`s every \`src/*.js\` and
  runs the extractor test under Node 22.

Manifest: bumped to **0.5.0**; description updated.

## Why this is the right wedge

The fanout autonomy loop is now end-to-end:
1. Research subscriptions bank fresh signals on a cron.
2. Operator subscriptions draft platform posts on a cron, biased by
   the leaderboard.
3. Extension posts the queued drafts via the user's browser session.
4. **Extension scrapes engagement back on a cron, feeds the leaderboard.**

Nothing in the chain requires a human in the loop once configured.