### PR TITLE
ci: fix broken extension job heredoc + add dependency-free research test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,22 @@ jobs:
       - name: Validate repository contract
         run: python3 scripts/check_repo_layout.py
 
+  research-stdlib:
+    name: Research loop (stdlib unittest, no deps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Pure-standard-library smoke check of the research loop's scoring /
+      # parsing / dedup logic. Installs nothing, so it fails fast and proves
+      # app.research stays dependency-free.
+      - name: Run stdlib unittest suite
+        run: python3 -m unittest discover -s tests -v
+
   backend:
     name: Backend (Python)
     runs-on: ubuntu-latest
@@ -117,6 +133,7 @@ jobs:
                   assert os.path.exists(js), f"missing file: {js}"
           assert os.path.exists(m["background"]["service_worker"])
           print("OK — all referenced files exist")
+          PY
 
       - uses: actions/setup-node@v6
         with:
@@ -131,4 +148,3 @@ jobs:
 
       - name: Run outcome-extractor tests
         run: node tests/test_outcomes.mjs
-          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ cd web && npm run dev
 
 ## Testing tips
 
+- **Full backend suite:** `cd backend && .venv/bin/pytest tests/ -q` (needs deps installed).
+- **Dependency-free smoke suite:** `python3 -m unittest discover -s tests` from the repo root — pure standard library, no install required, covers the `app.research` scoring/parsing/dedup logic.
 - Generate tests against Groq live (`.venv/bin/python /tmp/test_platforms.py` — see `docs/`).
 - Extension debugging: `chrome://extensions` → Fanout → "Inspect views: service worker" for background logs, or open any target platform tab and open DevTools for content script logs.
 - Backend: `uvicorn --reload` picks up changes automatically.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,34 @@ The repo includes [`.github/workflows/deploy-web.yml`](.github/workflows/deploy-
 
 This lets CI gate the deploy and post the live URL back to the commit.
 
+## Tests
+
+Two backend test suites, by design:
+
+```bash
+# Full suite — needs the backend deps installed (FastAPI, SQLAlchemy, …).
+# sqlite-backed store tests + mocked-HTTP research tests + operator/agent tests.
+cd backend
+.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pytest tests/ -q
+
+# Dependency-free smoke suite — pure standard library, runs from a clean
+# checkout with nothing installed. Locks down the research loop's scoring,
+# recency decay, ISO/RFC-822 parsing, dedup, and prompt formatting.
+python3 -m unittest discover -s tests          # run from the repo root
+```
+
+The stdlib suite (`tests/`) imports only `app.research`, which is itself
+standard-library-only, so it doubles as a guard that the research module never
+silently grows a third-party dependency. The extension has its own pure-Node
+smoke test:
+
+```bash
+node extension/tests/test_outcomes.mjs
+```
+
+All three run in CI (`.github/workflows/ci.yml`).
+
 ## Security
 
 See [SECURITY.md](SECURITY.md). Short version: the backend never holds your social

--- a/tests/_path.py
+++ b/tests/_path.py
@@ -1,0 +1,27 @@
+"""Make ``backend/app`` importable from the repo-root ``tests/`` package.
+
+These stdlib-``unittest`` tests deliberately live at the repository root (not
+under ``backend/tests/``) so they can be discovered and run with
+
+    python3 -m unittest discover -s tests
+
+from a clean checkout that has **no third-party dependencies installed**. The
+only module they exercise is ``app.research``, which is pure-standard-library,
+so the suite doubles as a fast dependency-free smoke check for the research
+loop's scoring / parsing / dedup logic.
+
+Importing this module prepends ``<repo>/backend`` to ``sys.path`` as a side
+effect, so test modules can simply ``import tests._path`` before importing
+``app.research``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_BACKEND = os.path.join(_REPO_ROOT, "backend")
+
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)

--- a/tests/test_research_scoring.py
+++ b/tests/test_research_scoring.py
@@ -1,0 +1,217 @@
+"""Stdlib-``unittest`` tests for the research module's pure logic.
+
+Scoring, normalisation, recency decay, dedup and prompt formatting are all
+pure functions with no I/O, so they are the highest-value things to lock down
+with a dependency-free suite. Run with::
+
+    python3 -m unittest discover -s tests
+
+The complementary network-boundary tests live in ``test_research_sources.py``;
+the original pytest suite under ``backend/tests/`` overlaps in spirit but
+requires the full dependency stack to be installed.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import tests._path  # noqa: F401  (side effect: puts backend/ on sys.path)
+
+from app import research  # noqa: E402
+from app.research import Snippet, format_for_prompt  # noqa: E402
+
+
+class RecencyFactorTests(unittest.TestCase):
+    def test_brand_new_content_scores_near_one(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        self.assertAlmostEqual(research._recency_factor(now, now=now), 1.0, places=3)
+
+    def test_half_life_content_scores_near_half(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        half = now - timedelta(hours=research.RECENCY_HALF_LIFE_HOURS)
+        self.assertAlmostEqual(research._recency_factor(half, now=now), 0.5, places=3)
+
+    def test_two_half_lives_scores_near_quarter(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        old = now - timedelta(hours=2 * research.RECENCY_HALF_LIFE_HOURS)
+        self.assertAlmostEqual(research._recency_factor(old, now=now), 0.25, places=3)
+
+    def test_unknown_timestamp_is_neutral(self) -> None:
+        # Opaque sources get a neutral 0.5 rather than a zero penalty.
+        self.assertEqual(research._recency_factor(None), 0.5)
+
+    def test_naive_datetime_is_treated_as_utc(self) -> None:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        naive = datetime(2026, 4, 26, 12, 0)  # no tzinfo
+        self.assertAlmostEqual(research._recency_factor(naive, now=now), 1.0, places=3)
+
+    def test_future_timestamp_is_clamped_not_amplified(self) -> None:
+        # A clock-skewed "future" item must not score above a brand-new one.
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        future = now + timedelta(hours=10)
+        self.assertAlmostEqual(research._recency_factor(future, now=now), 1.0, places=6)
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_zero_and_negative_clamp_to_zero(self) -> None:
+        self.assertEqual(research._normalize(0, soft_max=100), 0.0)
+        self.assertEqual(research._normalize(-50, soft_max=100), 0.0)
+
+    def test_output_is_bounded_to_unit_interval(self) -> None:
+        # Output saturates at 1.0 for very large values (exp underflow), so the
+        # closed interval [0, 1] is the contract, not the half-open [0, 1).
+        for value in (1, 50, 200, 10_000):
+            out = research._normalize(value, soft_max=100)
+            self.assertGreaterEqual(out, 0.0)
+            self.assertLessEqual(out, 1.0)
+
+    def test_monotonic_increasing(self) -> None:
+        small = research._normalize(10, soft_max=100)
+        big = research._normalize(500, soft_max=100)
+        self.assertLess(small, big)
+
+    def test_soft_max_curve_shape(self) -> None:
+        # At value == soft_max the curve is 1 - e^-1 ~= 0.632.
+        out = research._normalize(100, soft_max=100)
+        self.assertAlmostEqual(out, 1.0 - math.exp(-1), places=6)
+
+
+class ComposeScoreTests(unittest.TestCase):
+    def test_zero_popularity_scores_zero(self) -> None:
+        now = datetime.now(timezone.utc)
+        self.assertEqual(research._compose_score(0, soft_max=100, published_at=now), 0.0)
+
+    def test_high_popularity_fresh_scores_near_one(self) -> None:
+        now = datetime.now(timezone.utc)
+        out = research._compose_score(10_000, soft_max=100, published_at=now)
+        self.assertGreaterEqual(out, 0.9)
+        self.assertLessEqual(out, 1.0)
+
+    def test_geometric_mean_punishes_a_weak_factor(self) -> None:
+        # Popular but stale should score well below popular and fresh because
+        # the score is the geometric mean of popularity and recency.
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        fresh = research._compose_score(10_000, soft_max=100, published_at=now)
+        stale = research._compose_score(
+            10_000,
+            soft_max=100,
+            published_at=now - timedelta(hours=10 * research.RECENCY_HALF_LIFE_HOURS),
+        )
+        self.assertLess(stale, fresh)
+
+    def test_score_is_rounded_to_four_places(self) -> None:
+        now = datetime.now(timezone.utc)
+        out = research._compose_score(123, soft_max=100, published_at=now)
+        self.assertEqual(out, round(out, 4))
+
+
+class DedupeTests(unittest.TestCase):
+    def test_keeps_first_occurrence_of_a_url(self) -> None:
+        a = Snippet(source="hn", url="https://dup", title="first", score=0.9)
+        b = Snippet(source="reddit", url="https://dup", title="second", score=0.1)
+        c = Snippet(source="devto", url="https://unique", title="third", score=0.5)
+        out = research._dedupe_by_url([a, b, c])
+        self.assertEqual([s.title for s in out], ["first", "third"])
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(research._dedupe_by_url([]), [])
+
+
+class ParseIsoTests(unittest.TestCase):
+    def test_trailing_z_is_handled(self) -> None:
+        dt = research._parse_iso("2026-04-26T12:00:00Z")
+        self.assertIsNotNone(dt)
+        assert dt is not None  # for type-checkers
+        self.assertEqual(dt.tzinfo, timezone.utc)
+        self.assertEqual(dt.year, 2026)
+
+    def test_offset_form_is_handled(self) -> None:
+        dt = research._parse_iso("2026-04-26T12:00:00+00:00")
+        self.assertIsNotNone(dt)
+
+    def test_rfc822_pubdate_fallback(self) -> None:
+        # RSS <pubDate> uses RFC-822; fromisoformat rejects it, the email-utils
+        # fallback must catch it.
+        dt = research._parse_iso("Sun, 26 Apr 2026 12:00:00 +0000")
+        self.assertIsNotNone(dt)
+        assert dt is not None
+        self.assertEqual(dt.year, 2026)
+
+    def test_none_and_garbage_return_none(self) -> None:
+        self.assertIsNone(research._parse_iso(None))
+        self.assertIsNone(research._parse_iso(""))
+        self.assertIsNone(research._parse_iso("not a date at all"))
+
+
+class FromUnixTests(unittest.TestCase):
+    def test_valid_epoch_seconds(self) -> None:
+        dt = research._from_unix(1_700_000_000)
+        self.assertIsNotNone(dt)
+        assert dt is not None
+        self.assertEqual(dt.tzinfo, timezone.utc)
+
+    def test_string_seconds_are_coerced(self) -> None:
+        self.assertIsNotNone(research._from_unix("1700000000"))
+
+    def test_none_and_garbage_return_none(self) -> None:
+        self.assertIsNone(research._from_unix(None))
+        self.assertIsNone(research._from_unix("not-a-number"))
+
+
+class SnippetTests(unittest.TestCase):
+    def test_to_dict_serialises_datetime_to_iso(self) -> None:
+        published = datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc)
+        s = Snippet(source="hn", url="https://x", title="t", published_at=published)
+        d = s.to_dict()
+        self.assertEqual(d["published_at"], published.isoformat())
+        self.assertEqual(d["source"], "hn")
+
+    def test_to_dict_handles_none_datetime(self) -> None:
+        s = Snippet(source="hn", url="https://x", title="t")
+        self.assertIsNone(s.to_dict()["published_at"])
+
+    def test_extra_defaults_to_independent_dict(self) -> None:
+        a = Snippet(source="hn", url="https://a", title="a")
+        b = Snippet(source="hn", url="https://b", title="b")
+        a.extra["k"] = "v"
+        # The dataclass default_factory must not share one dict across instances.
+        self.assertEqual(b.extra, {})
+
+
+class FormatForPromptTests(unittest.TestCase):
+    def test_empty_input_returns_empty_string(self) -> None:
+        self.assertEqual(format_for_prompt([]), "")
+
+    def test_renders_source_and_url(self) -> None:
+        s = Snippet(source="hn", url="https://x", title="Title")
+        out = format_for_prompt([s])
+        self.assertIn("[hn]", out)
+        self.assertIn("Title", out)
+        self.assertIn("https://x", out)
+
+    def test_long_snippet_text_is_truncated_with_ellipsis(self) -> None:
+        s = Snippet(source="hn", url="https://x", title="t", snippet="y" * 500)
+        out = format_for_prompt([s])
+        self.assertIn("...", out)
+
+    def test_respects_max_chars_budget(self) -> None:
+        snippets = [
+            Snippet(source="hn", url=f"https://e/{i}", title=f"t{i}", snippet="x" * 400)
+            for i in range(50)
+        ]
+        out = format_for_prompt(snippets, max_chars=500)
+        # The loop appends-then-checks, so the cap is max_chars + the tail of
+        # one last line; assert it didn't run away to thousands of chars.
+        self.assertLessEqual(len(out), 900)
+        self.assertTrue(out.startswith("- [hn]"))
+
+    def test_snippetless_entries_render_single_line(self) -> None:
+        s = Snippet(source="rss", url="https://x", title="t")  # no snippet text
+        out = format_for_prompt([s])
+        self.assertEqual(out.count("\n"), 0)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_research_sources.py
+++ b/tests/test_research_sources.py
@@ -1,0 +1,278 @@
+"""Stdlib-``unittest`` tests for the research module's source fetchers.
+
+Every real network call funnels through ``research._http_get`` /
+``research._http_get_json``, so we patch those two functions with
+``unittest.mock.patch`` and never touch the network. This mirrors the intent
+of the original pytest suite but runs with only the standard library.
+
+Run with::
+
+    python3 -m unittest discover -s tests
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import tests._path  # noqa: F401  (side effect: puts backend/ on sys.path)
+
+from app import research  # noqa: E402
+
+# Error-path tests deliberately trigger ``log.warning`` calls (a flaky source
+# must degrade silently rather than crash the run). Silence them so the test
+# runner output stays clean — the assertions, not the log lines, prove the
+# behaviour.
+logging.getLogger("app.research").setLevel(logging.ERROR)
+from app.research import (  # noqa: E402
+    ResearchRequest,
+    Snippet,
+    fetch_devto,
+    fetch_hn,
+    fetch_reddit,
+    fetch_rss,
+    run_research,
+)
+
+
+def _iso(hours_ago: float) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class FetchHnTests(unittest.TestCase):
+    def test_parses_hits_and_drops_titleless(self) -> None:
+        payload = {
+            "hits": [
+                {
+                    "title": "Show HN: A neat thing",
+                    "url": "https://example.com/a",
+                    "author": "alice",
+                    "points": 120,
+                    "num_comments": 30,
+                    "created_at": _iso(4),
+                    "objectID": "1",
+                },
+                {
+                    "story_title": "Ask HN: Question",  # no url -> item fallback
+                    "objectID": "2",
+                    "points": 0,
+                    "num_comments": 0,
+                    "created_at": _iso(28),
+                },
+                {"objectID": "3"},  # no title -> dropped
+            ]
+        }
+        with mock.patch.object(research, "_http_get_json", return_value=payload):
+            out = fetch_hn("agents")
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0].url, "https://example.com/a")
+        self.assertEqual(out[0].source, "hn")
+        self.assertGreater(out[0].score, 0)
+        self.assertLessEqual(out[0].score, 1)
+        self.assertEqual(out[1].url, "https://news.ycombinator.com/item?id=2")
+
+    def test_empty_query_skips_network(self) -> None:
+        with mock.patch.object(research, "_http_get_json", side_effect=AssertionError):
+            self.assertEqual(fetch_hn("   "), [])
+
+    def test_network_error_degrades_to_empty_list(self) -> None:
+        with mock.patch.object(research, "_http_get_json", side_effect=OSError("down")):
+            self.assertEqual(fetch_hn("agents"), [])
+
+
+class FetchDevtoTests(unittest.TestCase):
+    def test_tag_is_normalised_and_invalid_rows_dropped(self) -> None:
+        captured = {}
+
+        def fake(url, timeout=5.0):
+            captured["url"] = url
+            return [
+                {
+                    "title": "Building agents",
+                    "url": "https://dev.to/x/agents",
+                    "description": "summary",
+                    "public_reactions_count": 50,
+                    "comments_count": 10,
+                    "published_at": _iso(8),
+                    "user": {"name": "Bob"},
+                },
+                {"title": "no url"},  # dropped
+            ]
+
+        with mock.patch.object(research, "_http_get_json", side_effect=fake):
+            out = fetch_devto("AI Agents")  # space + caps -> "ai-agents"
+        self.assertIn("tag=ai-agents", captured["url"])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].author, "Bob")
+
+    def test_punctuation_only_tag_skips_network(self) -> None:
+        with mock.patch.object(research, "_http_get_json", side_effect=AssertionError):
+            self.assertEqual(fetch_devto("!!!"), [])
+
+    def test_non_list_payload_returns_empty(self) -> None:
+        with mock.patch.object(research, "_http_get_json", return_value={"error": "x"}):
+            self.assertEqual(fetch_devto("python"), [])
+
+
+class FetchRedditTests(unittest.TestCase):
+    def test_parses_children(self) -> None:
+        payload = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "title": "AI agents are hot",
+                            "permalink": "/r/foo/comments/abc/",
+                            "selftext": "discussion",
+                            "ups": 200,
+                            "num_comments": 80,
+                            "created_utc": (
+                                datetime.now(timezone.utc) - timedelta(hours=4)
+                            ).timestamp(),
+                            "author": "u1",
+                            "subreddit": "foo",
+                        }
+                    },
+                    {"data": {"title": "no permalink"}},  # dropped
+                ]
+            }
+        }
+        with mock.patch.object(research, "_http_get_json", return_value=payload):
+            out = fetch_reddit("agents")
+        self.assertEqual(len(out), 1)
+        self.assertTrue(out[0].url.startswith("https://www.reddit.com/r/foo/comments/"))
+        self.assertEqual(out[0].extra["subreddit"], "foo")
+        self.assertGreater(out[0].score, 0)
+
+    def test_empty_query_skips_network(self) -> None:
+        with mock.patch.object(research, "_http_get_json", side_effect=AssertionError):
+            self.assertEqual(fetch_reddit(""), [])
+
+
+class FetchRssTests(unittest.TestCase):
+    def test_rss20_shape(self) -> None:
+        pubdate = (datetime.now(timezone.utc) - timedelta(hours=4)).strftime(
+            "%a, %d %b %Y %H:%M:%S +0000"
+        )
+        body = (
+            '<?xml version="1.0"?><rss><channel>'
+            f"<item><title>Item A</title><link>https://a.example</link>"
+            f"<description>desc</description><pubDate>{pubdate}</pubDate></item>"
+            "<item><title>No link</title></item>"
+            "</channel></rss>"
+        ).encode()
+        with mock.patch.object(research, "_http_get", return_value=body):
+            out = fetch_rss("https://blog.example/feed.xml")
+        self.assertEqual([s.title for s in out], ["Item A"])
+        self.assertGreater(out[0].score, 0)
+
+    def test_atom_shape(self) -> None:
+        updated = (datetime.now(timezone.utc) - timedelta(hours=4)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        body = (
+            '<?xml version="1.0"?>'
+            '<feed xmlns="http://www.w3.org/2005/Atom"><entry>'
+            "<title>Atom A</title><link href=\"https://a.atom\"/>"
+            f"<summary>summary</summary><updated>{updated}</updated>"
+            "<author><name>Bob</name></author></entry></feed>"
+        ).encode()
+        with mock.patch.object(research, "_http_get", return_value=body):
+            out = fetch_rss("https://blog.example/atom.xml")
+        self.assertEqual([s.title for s in out], ["Atom A"])
+        self.assertEqual(out[0].author, "Bob")
+        self.assertEqual(out[0].url, "https://a.atom")
+
+    def test_bad_xml_returns_empty(self) -> None:
+        with mock.patch.object(research, "_http_get", return_value=b"<not-valid>"):
+            self.assertEqual(fetch_rss("https://blog.example/feed.xml"), [])
+
+    def test_network_error_returns_empty(self) -> None:
+        with mock.patch.object(research, "_http_get", side_effect=OSError("down")):
+            self.assertEqual(fetch_rss("https://blog.example/feed.xml"), [])
+
+
+class RunResearchTests(unittest.TestCase):
+    def _patch_fetchers(self, **overrides):
+        base = {
+            "hn": lambda q, n: [],
+            "devto": lambda q, n: [],
+            "reddit": lambda q, n: [],
+            "rss": lambda q, n: [],
+        }
+        base.update(overrides)
+        return mock.patch.dict(research.SOURCE_FETCHERS, base, clear=True)
+
+    def test_dedupes_by_url_keeping_highest_score(self) -> None:
+        shared = "https://example.com/x"
+        with self._patch_fetchers(
+            hn=lambda q, n: [Snippet(source="hn", url=shared, title="HN", score=0.4)],
+            reddit=lambda q, n: [
+                Snippet(source="reddit", url=shared, title="Reddit", score=0.8)
+            ],
+        ):
+            result = run_research(
+                ResearchRequest(queries=["agents"], sources=["hn", "reddit", "devto"])
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].source, "reddit")
+        self.assertEqual(result[0].score, 0.8)
+
+    def test_results_are_sorted_by_score_desc(self) -> None:
+        with self._patch_fetchers(
+            hn=lambda q, n: [
+                Snippet(source="hn", url="https://low", title="low", score=0.2),
+                Snippet(source="hn", url="https://high", title="high", score=0.9),
+            ],
+        ):
+            result = run_research(ResearchRequest(queries=["x"], sources=["hn"]))
+        self.assertEqual([s.score for s in result], [0.9, 0.2])
+
+    def test_one_source_failure_does_not_crash_run(self) -> None:
+        def bad(q, n):
+            raise RuntimeError("boom")
+
+        with self._patch_fetchers(
+            hn=lambda q, n: [Snippet(source="hn", url="https://ok", title="ok", score=0.5)],
+            reddit=bad,
+        ):
+            result = run_research(
+                ResearchRequest(queries=["agents"], sources=["hn", "reddit"])
+            )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].url, "https://ok")
+
+    def test_no_jobs_returns_empty(self) -> None:
+        self.assertEqual(run_research(ResearchRequest(queries=[], rss_feeds=[])), [])
+
+    def test_blank_queries_produce_no_jobs(self) -> None:
+        with self._patch_fetchers(
+            hn=lambda q, n: [Snippet(source="hn", url="https://x", title="t", score=1.0)],
+        ):
+            result = run_research(ResearchRequest(queries=["   ", ""], sources=["hn"]))
+        self.assertEqual(result, [])
+
+    def test_rss_feeds_drive_rss_source_only(self) -> None:
+        captured = []
+
+        def rss(feed, n):
+            captured.append(feed)
+            return [Snippet(source="rss", url=feed, title="t", score=0.3)]
+
+        with self._patch_fetchers(rss=rss):
+            result = run_research(
+                ResearchRequest(
+                    queries=[],
+                    rss_feeds=["https://a/feed", "https://b/feed"],
+                    sources=["rss"],
+                )
+            )
+        self.assertEqual(sorted(captured), ["https://a/feed", "https://b/feed"])
+        self.assertEqual(len(result), 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## What

Two genuine improvements, validated locally before opening:

### 1. Fix a real CI bug in the `extension` job
`.github/workflows/ci.yml` had a malformed heredoc in the `extension` job:

- The **"Check content script files exist"** step opened `python3 - <<'PY'` but never closed it.
- A stray `PY` delimiter dangled off the end of the **"Run outcome-extractor tests"** step, so that step's command became `node tests/test_outcomes.mjs` followed by a bogus `PY` token — a guaranteed failure once that job ran.

Closed the first heredoc with its `PY` terminator and removed the orphan delimiter. The extension job is now structurally sound (verified: 2 heredoc openers, 2 matching closers at the correct indent).

### 2. Add a dependency-free `unittest` test suite
New standard-library-only suite at the repo root (`tests/`), runnable from a clean checkout with **zero third-party dependencies**:

```bash
python3 -m unittest discover -s tests
```

It exercises the real `app.research` module (itself stdlib-only) — **49 tests**, covering:

- recency half-life decay (`_recency_factor`) incl. naive-tz and clock-skew/future handling
- soft-max popularity normalisation (`_normalize`) bounds + monotonicity + curve shape
- geometric-mean scoring (`_compose_score`) incl. the "popular but stale loses to popular + fresh" property
- URL dedup ordering (`_dedupe_by_url`)
- ISO-8601 (trailing `Z` / offset) **and** RFC-822 `pubDate` fallback parsing (`_parse_iso`)
- unix-epoch coercion (`_from_unix`)
- `Snippet.to_dict` serialisation + per-instance `extra` default
- `format_for_prompt` rendering, truncation, and `max_chars` budget
- every source fetcher (HN / Dev.to / Reddit / RSS) and `run_research` orchestration (dedup, score-desc sort, per-source error isolation, blank-query skipping) via mocked HTTP at the `_http_get` boundary — no network

A new `research-stdlib` CI job runs this suite, guarding that `app.research` never silently grows a third-party dependency. This complements (does not replace) the existing pytest suite under `backend/tests/`, which needs the full dependency stack.

### 3. Docs
Documented both test suites in `README.md` (new **Tests** section) and `CONTRIBUTING.md`.

## Validation

- `python3 -m unittest discover -s tests` → **49 passed** (Python 3.14.5 locally; CI runs 3.12)
- `python3 -m py_compile $(git ls-files '*.py')` → clean
- Heredoc balance check on the workflow → 2 openers / 2 closers, matched indent

`app.agent`, `app.operator`, `app.store`, etc. require third-party deps (groq, sqlalchemy, fastapi) that aren't installed in this environment, so the existing pytest suite was not run here — it is unchanged and still wired into the `backend` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)